### PR TITLE
CMake: Remove Qt5 Gui dependency - it ruins oe ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(GenerateExportHeader)
 
 option(useSystemd "Using libsystemd" ON)
 
-find_package(Qt5 COMPONENTS Core Gui Xml Network Test CONFIG REQUIRED)
+find_package(Qt5 COMPONENTS Core Xml Network Test CONFIG REQUIRED)
 find_package(SCPI REQUIRED)
 find_package(scpi-tcp REQUIRED)
 find_package(xiqnet REQUIRED)

--- a/com5003d/CMakeLists.txt
+++ b/com5003d/CMakeLists.txt
@@ -104,7 +104,6 @@ endif()
 target_link_libraries(com5003d-lib
     PUBLIC
     Qt5::Core
-    Qt5::Gui
     Qt5::Xml
     Qt5::Network
     ZeraClasses::zerai2c

--- a/mt310s2d/CMakeLists.txt
+++ b/mt310s2d/CMakeLists.txt
@@ -124,7 +124,6 @@ endif()
 target_link_libraries(mt310s2d-lib
     PUBLIC
     Qt5::Core
-    Qt5::Gui
     Qt5::Xml
     Qt5::Network
     ZeraClasses::zerai2c

--- a/sec1000d/CMakeLists.txt
+++ b/sec1000d/CMakeLists.txt
@@ -65,7 +65,6 @@ target_link_libraries(sec1000d-lib
     PUBLIC
     Qt5::Xml
     Qt5::Network
-    Qt5::Gui
     ZeraClasses::zeramisc 
     ZeraClasses::zeraxmlconfig 
     VeinMeta::VfProtobuf


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>