### PR TITLE
Use ScpiSingletonFactory in cMT310S2dServer/cCOM5003dServer

### DIFF
--- a/com5003d/com5003d.cpp
+++ b/com5003d/com5003d.cpp
@@ -38,6 +38,7 @@
 #include "samplingsettings.h"
 #include "foutsettings.h"
 #include "scinsettings.h"
+#include <scpisingletonfactory.h>
 
 #ifdef SYSTEMD_NOTIFICATION
 #include <systemd/sd-daemon.h>
@@ -46,7 +47,7 @@
 cATMEL* pAtmel; // we take a static object for atmel connection
 
 cCOM5003dServer::cCOM5003dServer() :
-    cPCBServer(ServerName, ServerVersion)
+    cPCBServer(ServerName, ServerVersion, ScpiSingletonFactory::getScpiObj(ServerName))
 {
     m_pDebugSettings = nullptr;
     m_pETHSettings = nullptr;

--- a/mt310s2d/src/mt310s2d.cpp
+++ b/mt310s2d/src/mt310s2d.cpp
@@ -26,6 +26,7 @@
 #include "scinsettings.h"
 #include "sensesettings.h"
 #include "foutsettings.h"
+#include <scpisingletonfactory.h>
 #include <xmlconfigreader.h>
 #include <xiqnetserver.h>
 #include <QSocketNotifier>
@@ -62,7 +63,7 @@ cATMELSysCtrl* pAtmelSys; // we take a static object for atmel connection
 cATMEL* pAtmel; // we take a static object for atmel connection
 
 cMT310S2dServer::cMT310S2dServer() :
-    cPCBServer(ServerName, ServerVersion)
+    cPCBServer(ServerName, ServerVersion, ScpiSingletonFactory::getScpiObj(ServerName))
 {
     m_pDebugSettings = nullptr;
     m_pETHSettings = nullptr;

--- a/zenux-service-common/lib/scpi-interfaces/pcbserver.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/pcbserver.cpp
@@ -8,7 +8,6 @@
 #include <xmlconfigreader.h>
 #include <xiqnetserver.h>
 #include <scpi.h>
-#include <scpisingletonfactory.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <QtDebug>
@@ -26,8 +25,8 @@ enum commands
     cmdUnregister
 };
 
-cPCBServer::cPCBServer(QString name, QString version) :
-    ScpiConnection(ScpiSingletonFactory::getScpiObj(name)),
+cPCBServer::cPCBServer(QString name, QString version, cSCPI *scpiInterface) :
+    ScpiConnection(scpiInterface),
     m_sServerName(name),
     m_sServerVersion(version)
 {

--- a/zenux-service-common/lib/scpi-interfaces/pcbserver.h
+++ b/zenux-service-common/lib/scpi-interfaces/pcbserver.h
@@ -19,7 +19,7 @@ class cPCBServer: public ScpiConnection
 {
     Q_OBJECT
 public:
-    explicit cPCBServer(QString name, QString version);
+    explicit cPCBServer(QString name, QString version, cSCPI *scpiInterface);
     void initSCPIConnection(QString leadingNodes) override;
     cSCPI* getSCPIInterface();
     QString& getName();


### PR DESCRIPTION
This way everytime a new cSCPI interface is created and used in pcbserver
Signed-off-by: Anuja Mutalik <a.mutalik@zera.de>