### PR TITLE
Follow zera-scpi/cSCPI/exportSCPIModelXML api change

### DIFF
--- a/com5003d/com5003d.cpp
+++ b/com5003d/com5003d.cpp
@@ -45,7 +45,7 @@
 #endif
 
 cCOM5003dServer::cCOM5003dServer() :
-    cPCBServer(ServerName, ServerVersion, ScpiSingletonFactory::getScpiObj(ServerName))
+    cPCBServer(ServerName, ServerVersion, ScpiSingletonFactory::getScpiObj())
 {
     m_pDebugSettings = nullptr;
     m_pETHSettings = nullptr;

--- a/mt310s2d/src/mt310s2d.cpp
+++ b/mt310s2d/src/mt310s2d.cpp
@@ -61,7 +61,7 @@ static struct sigaction mySigAction;
 cATMELSysCtrl* pAtmelSys; // we take a static object for atmel connection
 
 cMT310S2dServer::cMT310S2dServer() :
-    cPCBServer(ServerName, ServerVersion, ScpiSingletonFactory::getScpiObj(ServerName))
+    cPCBServer(ServerName, ServerVersion, ScpiSingletonFactory::getScpiObj())
 {
     m_pDebugSettings = nullptr;
     m_pETHSettings = nullptr;

--- a/mt310s2d/tests/senserangetesttemplate.cpp
+++ b/mt310s2d/tests/senserangetesttemplate.cpp
@@ -2,7 +2,7 @@
 
 void SenseRangeTestTemplate::_init(QString leadingNodes, QString alias, double rValue, double rejection, double ovrejection, double adcrejection, quint16 mmask)
 {
-    scpi = new cSCPI("foo");
+    scpi = new cSCPI();
     justData = new JustRangeTripletOffsetGainPhase(scpi);
     testRange = new cSenseRange(scpi, alias, alias, true, rValue, rejection, ovrejection, adcrejection, 0, mmask, justData);
     testRange->initSCPIConnection(leadingNodes);

--- a/mt310s2d/tests/test_accumulatorinterface.cpp
+++ b/mt310s2d/tests/test_accumulatorinterface.cpp
@@ -11,7 +11,7 @@ static const char *systemAccumulatorSoc ="SYSTEM:ACCUMULATOR:SOC?";
 void test_accumulatorinterface::init()
 {
     TimerFactoryQtForTest::enableTest();
-    m_scpiInterface = std::make_unique<cSCPI>("");
+    m_scpiInterface = std::make_unique<cSCPI>();
     m_atmelSysCntrl = std::make_unique<AtmelSysCntrlTest>("", 0, 0);
 
     m_xmlConfigReader = std::make_unique<Zera::XMLConfig::cReader>();

--- a/sec1000d/ecalcchannel.cpp
+++ b/sec1000d/ecalcchannel.cpp
@@ -19,7 +19,7 @@
 extern void SigHandler(int);
 
 cECalculatorChannel::cECalculatorChannel(cSEC1000dServer* server, cECalculatorSettings* esettings, FPGASettings* fsettings, cInputSettings *inpsettings, quint16 nr) :
-    ScpiConnection(ScpiSingletonFactory::getScpiObj(ServerName)),
+    ScpiConnection(ScpiSingletonFactory::getScpiObj()),
     m_pMyServer(server),
     m_pecalcsettings(esettings),
     m_pFPGASettings(fsettings),

--- a/sec1000d/ecalcinterface.cpp
+++ b/sec1000d/ecalcinterface.cpp
@@ -9,7 +9,7 @@
 #include <xmlsettings.h>
 
 cECalculatorInterface::cECalculatorInterface(cSEC1000dServer* server, EthSettingsSec* ethsettings, cECalculatorSettings* ecalcSettings, FPGASettings* fpgasettings, cInputSettings *inputsettings) :
-    cResource(ScpiSingletonFactory::getScpiObj(ServerName)),
+    cResource(ScpiSingletonFactory::getScpiObj()),
     m_pMyServer(server),
     m_pETHsettings(ethsettings),
     m_pecalcsettings(ecalcSettings),

--- a/sec1000d/pcbserver.cpp
+++ b/sec1000d/pcbserver.cpp
@@ -27,7 +27,7 @@ enum commands
 };
 
 cPCBServer::cPCBServer(QString name, QString version) :
-    ScpiConnection(ScpiSingletonFactory::getScpiObj(name)),
+    ScpiConnection(ScpiSingletonFactory::getScpiObj()),
     m_sServerName(name),
     m_sServerVersion(version)
 {

--- a/sec1000d/statusinterface.cpp
+++ b/sec1000d/statusinterface.cpp
@@ -4,7 +4,7 @@
 #include "scpisingletonfactory.h"
 
 cStatusInterface::cStatusInterface() :
-    ScpiConnection(ScpiSingletonFactory::getScpiObj(ServerName))
+    ScpiConnection(ScpiSingletonFactory::getScpiObj())
 {
 }
 

--- a/sec1000d/systeminterface.cpp
+++ b/sec1000d/systeminterface.cpp
@@ -10,7 +10,7 @@
 
 
 cSystemInterface::cSystemInterface(cSEC1000dServer *server, cSystemInfo *sInfo) :
-    ScpiConnection(ScpiSingletonFactory::getScpiObj(ServerName)),
+    ScpiConnection(ScpiSingletonFactory::getScpiObj()),
     m_pMyServer(server),
     m_pSystemInfo(sInfo)
 {
@@ -191,7 +191,7 @@ QString cSystemInterface::m_InterfaceRead(QString &sInput)
     if (cmd.isQuery())
     {
         QString s;
-        ScpiSingletonFactory::getScpiObj(ServerName)->exportSCPIModelXML(s);
+        ScpiSingletonFactory::getScpiObj()->exportSCPIModelXML(s);
         return s;
     }
     else

--- a/zenux-service-common/tests/test_asynchnotificationsinterface.cpp
+++ b/zenux-service-common/tests/test_asynchnotificationsinterface.cpp
@@ -8,7 +8,7 @@ QTEST_MAIN(test_asynchnotificationsinterface);
 
 void test_asynchnotificationsinterface::init()
 {
-    m_scpiInterface = std::make_unique<cSCPI>("foo");
+    m_scpiInterface = std::make_unique<cSCPI>();
 }
 
 void test_asynchnotificationsinterface::findScpiRegisterObject()

--- a/zenux-service-common/tests/test_authorizationnotifier.cpp
+++ b/zenux-service-common/tests/test_authorizationnotifier.cpp
@@ -16,7 +16,7 @@ constexpr quint16 NOTIFICATION_ID = 1;
 
 void test_authorizationnotifier::init()
 {
-    cSCPI *scpiInterface = new cSCPI("foo");
+    cSCPI *scpiInterface = new cSCPI();
     m_atmel = new MockAtmel();
     m_pcbServerTest = std::make_unique<PCBTestServer>("foo", "0", scpiInterface, m_atmel);
     m_adjustmentStatusNull = new AdjustmentStatusNull();

--- a/zenux-service-common/tests/test_justdata.cpp
+++ b/zenux-service-common/tests/test_justdata.cpp
@@ -8,7 +8,7 @@ static constexpr int digits = 4;
 
 void test_justdata::init()
 {
-    scpi = new cSCPI("foo");
+    scpi = new cSCPI();
     justData = new JustDataInterface({scpi, 5, 0.1, [] (bool &enable) { enable =true; return true;}, digits});
     justData->initSCPIConnection("sens:m0:8V:corr:offset");
 }

--- a/zenux-service-common/tests/test_serverunregisternotifier.cpp
+++ b/zenux-service-common/tests/test_serverunregisternotifier.cpp
@@ -11,8 +11,7 @@ static const char *accumulatorStatusCommand ="SYSTEM:ACCUMULATOR:STATUS?";
 
 constexpr quint16 NOTIFICATION_ID = 1;
 
-test_serverunregisternotifier::test_serverunregisternotifier() :
-    m_scpiInterface("foo")
+test_serverunregisternotifier::test_serverunregisternotifier()
 {
 }
 


### PR DESCRIPTION
* cSCPI no longer needs scpi-interface name (it was used only for DEVICE tag)
* Remove DEVICE tag from xml created using exportSCPIModelXML. Perhaps it was not needed there, it was done to make zera-scpi happy