### PR TITLE
Revert "CMake: Increase min version to fix warning on recent Fedora"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(zenux-services LANGUAGES CXX)
 


### PR DESCRIPTION
It caused unforseeable results in zera-classes

This reverts commit 3ad0d600b9059bcd26b4b1037300bbe64b3e4786.