### PR TITLE
com5003: Add tests for range constant values

### DIFF
--- a/com5003d/tests/regression_data.qrc
+++ b/com5003d/tests/regression_data.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
         <file>regression_data/adjustment_export.xml</file>
+        <file>regression_data/all-ranges-il3.json</file>
     </qresource>
 </RCC>

--- a/com5003d/tests/regression_data/all-ranges-il3.json
+++ b/com5003d/tests/regression_data/all-ranges-il3.json
@@ -1,0 +1,123 @@
+{
+    "no-clamps": {
+        "1.0A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "1"
+        },
+        "100A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "100"
+        },
+        "100mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.1"
+        },
+        "10A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "10"
+        },
+        "10mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.01"
+        },
+        "2.5A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "2.5"
+        },
+        "200A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.25608e+06",
+            "rejection": "6.25724e+06",
+            "urval": "200"
+        },
+        "250mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.25"
+        },
+        "25A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "25"
+        },
+        "25mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.025"
+        },
+        "500mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.5"
+        },
+        "50A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "50"
+        },
+        "50mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.05"
+        },
+        "5A": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "5"
+        },
+        "5mA": {
+            "adcrejection": "8.38861e+06",
+            "avail": "1",
+            "ovrejection": "5.86616e+06",
+            "rejection": "4.69293e+06",
+            "urval": "0.005"
+        },
+        "R0V": {
+            "adcrejection": "8.38861e+06",
+            "avail": "0",
+            "ovrejection": "5.33287e+06",
+            "rejection": "3.83967e+06",
+            "urval": "9"
+        },
+        "R10V": {
+            "adcrejection": "8.38861e+06",
+            "avail": "0",
+            "ovrejection": "5.33287e+06",
+            "rejection": "4.2663e+06",
+            "urval": "10"
+        }
+    }
+}

--- a/com5003d/tests/test_regression_sense_interface_com5003.cpp
+++ b/com5003d/tests/test_regression_sense_interface_com5003.cpp
@@ -1,9 +1,11 @@
 #include "test_regression_sense_interface_com5003.h"
 #include "proxy.h"
-#include "reply.h"
 #include "pcbinterface.h"
 #include <timemachineobject.h>
+#include "regressionhelper.h"
 #include <QRegularExpression>
+#include <QJsonValue>
+#include <QJsonDocument>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -94,4 +96,89 @@ void test_regression_sense_interface_com5003::checkRangesIL1()
     m_pcbIFace->getRangeList(channelSetting->m_nameMx);
     TimeMachineObject::feedEventLoop();
     QCOMPARE(responseSpy[0][2].toStringList(), m_rangesExpectedI);
+}
+
+void test_regression_sense_interface_com5003::constantRangeValuesIL3GenJson()
+{
+    genJsonConstantValuesAllRanges("IL3");
+}
+
+void test_regression_sense_interface_com5003::constantRangeValuesIL3Check()
+{
+    QJsonObject json = loadJson(":/regression_data/all-ranges-il3.json");
+    QVERIFY(!json.isEmpty());
+    QVERIFY(checkJsonConstantValuesAllRanges(json, "IL3"));
+
+}
+
+static QString noClampJsonId = QStringLiteral("no-clamps");
+
+void test_regression_sense_interface_com5003::genJsonConstantValuesAllRanges(QString channelName)
+{
+    SenseSystem::cChannelSettings *channelSetting = m_mockServer->getSenseSettings()->findChannelSettingByAlias1(channelName);
+    QJsonObject jsonAll;
+
+    QSignalSpy responseSpy(m_pcbIFace.get(), &Zera::cPCBInterface::serverAnswer);
+    m_pcbIFace->getRangeList(channelSetting->m_nameMx);
+    TimeMachineObject::feedEventLoop();
+
+    QJsonObject jsonRanges;
+    const QStringList ranges = responseSpy[0][2].toStringList();
+    for(const QString &range : ranges) {
+        QJsonObject jsonRange;
+        RegressionHelper::addRangeConstantDataToJson(range, channelSetting, jsonRange);
+        jsonRanges.insert(range, jsonRange);
+    }
+
+    // same struture ad mt310s2 - no clamps yet
+    jsonAll.insert(noClampJsonId, jsonRanges);
+
+    QJsonDocument doc(jsonAll);
+    qInfo("----------------- json range constants generated for %s -----------------", qPrintable(channelName));
+    qInfo("%s", qPrintable(doc.toJson(QJsonDocument::Indented)));
+}
+
+bool test_regression_sense_interface_com5003::checkJsonConstantValuesAllRanges(QJsonObject jsonReference, QString channelName)
+{
+    bool allCheckOk = true;
+    SenseSystem::cChannelSettings *channelSetting = m_mockServer->getSenseSettings()->findChannelSettingByAlias1(channelName);
+
+    QSignalSpy responseSpy(m_pcbIFace.get(), &Zera::cPCBInterface::serverAnswer);
+    m_pcbIFace->getRangeList(channelSetting->m_nameMx);
+    TimeMachineObject::feedEventLoop();
+
+    if(jsonReference.contains(noClampJsonId)) {
+        QJsonObject jsonRanges = jsonReference.value(noClampJsonId).toObject();
+        if(!jsonRanges.isEmpty()) {
+            const QStringList ranges = responseSpy[0][2].toStringList();
+            if(!ranges.isEmpty()) {
+                for(const QString &range : ranges) {
+                    QJsonObject jsonRange = jsonRanges.value(range).toObject();
+                    if(!RegressionHelper::compareRangeConstantDataWithJson(jsonRange, noClampJsonId, range, channelSetting))
+                        allCheckOk = false;
+                }
+            }
+            else {
+                allCheckOk = false;
+                qCritical("No ranges returned from device for clamp \"%s\"", qPrintable(noClampJsonId));
+            }
+        }
+        else {
+            allCheckOk = false;
+            qCritical("No ranges found in reference for clamp \"%s\"", qPrintable(noClampJsonId));
+        }
+    }
+    else {
+        allCheckOk = false;
+        qCritical("Clamp \"%s\" not found in reference", qPrintable(noClampJsonId));
+    }
+    return allCheckOk;
+}
+
+QJsonObject test_regression_sense_interface_com5003::loadJson(QString fileName)
+{
+    QFile referencFile(fileName);
+    referencFile.open(QFile::ReadOnly);
+    QJsonDocument doc = QJsonDocument::fromJson(referencFile.readAll());
+    return doc.object();
 }

--- a/com5003d/tests/test_regression_sense_interface_com5003.h
+++ b/com5003d/tests/test_regression_sense_interface_com5003.h
@@ -5,6 +5,8 @@
 #include "pcbinterface.h"
 #include "resmanrunfacade.h"
 #include <QObject>
+#include <QStringList>
+#include <QJsonObject>
 
 class test_regression_sense_interface_com5003 : public QObject
 {
@@ -17,7 +19,13 @@ private slots:
     void checkChannelCatalogAsExpected();
     void checkRangesUL1();
     void checkRangesIL1();
+    void constantRangeValuesIL3GenJson();
+    void constantRangeValuesIL3Check();
 private:
+    void genJsonConstantValuesAllRanges(QString channelName);
+    bool checkJsonConstantValuesAllRanges(QJsonObject jsonReference, QString channelName);
+    QJsonObject loadJson(QString fileName);
+
     std::unique_ptr<MockForSenseInterfaceCom5003> m_mockServer;
     std::unique_ptr<ResmanRunFacade> m_resmanServer;
     Zera::ProxyClientPtr m_pcbClient;


### PR DESCRIPTION
Let's remember where this mission started:
Our target was to find out differences between implementation of SCPI interface in COM5003 / MT310s2. Although we almost forgot during the jorney, we reached that target.

Now that we have informational data, a reliable test harness and learned a lot, we are better off merging the two implementations to one.

Next step should be:
Check if our assumption that rejection values are used only on range module to decide on overload conditions and no measurement accuracy is affected.