### PR TITLE
Fix build of zera-classes with simul gui enabled

### DIFF
--- a/ZenuxServicesConfig.cmake.in
+++ b/ZenuxServicesConfig.cmake.in
@@ -1,6 +1,9 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(Qt5 COMPONENTS Core Xml Network Test CONFIG REQUIRED)
+if(@GUI_SIMULATION@)
+    find_dependency(Qt5 COMPONENTS Qml Quick CONFIG REQUIRED)
+endif()
 find_dependency(SCPI REQUIRED)
 find_dependency(ZenuxCore REQUIRED)
 find_dependency(ZeraMicroController REQUIRED)


### PR DESCRIPTION
This is a follow up on vf-logger not using qml-scripts anymore