### PR TITLE
All servers: Make register resources finish detection more robust

### DIFF
--- a/com5003d/lib/com5003d.cpp
+++ b/com5003d/lib/com5003d.cpp
@@ -376,6 +376,7 @@ void cCOM5003dServer::onResourceReady()
 {
     Q_ASSERT(m_pendingResources > 0);
     m_pendingResources--;
+    disconnect(static_cast<cResource*>(sender()), &cResource::registerRdy, this, &cCOM5003dServer::onResourceReady);
     if(m_pendingResources == 0) {
         EthSettings *ethSettings = m_settings->getEthSettings();
         m_myServer->startServer(ethSettings->getPort(EthSettings::protobufserver));

--- a/com5003d/lib/scpi-interfaces/com5003senseinterface.cpp
+++ b/com5003d/lib/scpi-interfaces/com5003senseinterface.cpp
@@ -59,7 +59,7 @@ Com5003SenseInterface::Com5003SenseInterface(cSCPI *scpiInterface,
     // we must use a statemachine because we have to synchronize sending of notifier
     // otherwise moduls using this notifier will crash because resources are not registered properly
 
-    m_UnregisterSenseState.addTransition(this, &Com5003SenseInterface::registerRdy, &m_RegisterSenseState);
+    m_UnregisterSenseState.addTransition(this, &Com5003SenseInterface::unregisterRdy, &m_RegisterSenseState);
     m_RegisterSenseState.addTransition(this, &Com5003SenseInterface::registerRdy, &m_NotifySenseState);
     m_ChangeSenseModeMachine.addState(&m_UnregisterSenseState);
     m_ChangeSenseModeMachine.addState(&m_RegisterSenseState);
@@ -223,7 +223,6 @@ AdjRangeScpi *Com5003SenseInterface::createJustScpiInterfaceWithAtmelPermission(
 void Com5003SenseInterface::unregisterSense()
 {
     SenseChannelCommon* pChannel;
-    m_msgNrList.clear();
     for (int i = 0; i < 6; i++) {
         pChannel = m_channelList.at(i);
         unregister1Resource(m_rmConnection, NotZeroNumGen::getMsgNr(), QString("SENSE;%1;")

--- a/mt310s2d/lib/mt310s2d.cpp
+++ b/mt310s2d/lib/mt310s2d.cpp
@@ -312,6 +312,7 @@ void cMT310S2dServer::onResourceReady()
 {
     Q_ASSERT(m_pendingResources > 0);
     m_pendingResources--;
+    disconnect(static_cast<cResource*>(sender()), &cResource::registerRdy, this, &cMT310S2dServer::onResourceReady);
     if(m_pendingResources == 0) {
         EthSettings *ethSettings = m_settings->getEthSettings();
         m_myServer->startServer(ethSettings->getPort(EthSettings::protobufserver));

--- a/sec1000d/lib/sec1000d.cpp
+++ b/sec1000d/lib/sec1000d.cpp
@@ -228,6 +228,7 @@ void cSEC1000dServer::onResourceReady()
 {
     Q_ASSERT(m_pendingResources > 0);
     m_pendingResources--;
+    disconnect(static_cast<cResource*>(sender()), &cResource::registerRdy, this, &cSEC1000dServer::onResourceReady);
     if(m_pendingResources == 0) {
         EthSettings *ethSettings = m_settings->getEthSettings();
         m_myServer->startServer(ethSettings->getPort(EthSettings::protobufserver));

--- a/zdsp1d/lib/zdspserver.cpp
+++ b/zdsp1d/lib/zdspserver.cpp
@@ -239,7 +239,7 @@ void ZDspServer::doIdentAndRegister()
     EthSettings *ethSettings = m_settings->getEthSettings();
     quint32 port = ethSettings->getPort(EthSettings::protobufserver);
 
-    connect(&m_resourceRegister, &ResourceRegisterTransaction::registerDone, this, &ZDspServer::onResourceReady);
+    connect(&m_resourceRegister, &ResourceRegisterTransaction::registerRdy, this, &ZDspServer::onResourceReady);
     m_resourceRegister.register1Resource(QString("DSP;DSP1;;ADSP Signal Processor;%1;").arg(port));
     TDspVar* pDspVar = &CmdListVar;
     m_resourceRegister.register1Resource(QString("DSP1;PGRMEMI;%1;DSP ProgramMemory(Interrupt);%2;").arg(pDspVar->size).arg(port));
@@ -251,6 +251,7 @@ void ZDspServer::doIdentAndRegister()
 
 void ZDspServer::onResourceReady()
 {
+    disconnect(&m_resourceRegister, &ResourceRegisterTransaction::registerRdy, this, &ZDspServer::onResourceReady);
     EthSettings *ethSettings = m_settings->getEthSettings();
     myProtonetServer->startServer(ethSettings->getPort(EthSettings::protobufserver)); // and can start the server now
     if (ethSettings->isSCPIactive()) {

--- a/zenux-service-common/lib/resources/resource.cpp
+++ b/zenux-service-common/lib/resources/resource.cpp
@@ -10,19 +10,21 @@ cResource::cResource(cSCPI *scpiInterface) :
 void cResource::register1Resource(RMConnection *rmConnection, quint32 msgnr, QString registerParameter)
 {
     QString cmd = QString("RESOURCE:ADD");
-    m_msgNrList.append(msgnr);
+    m_msgNrListRegister.append(msgnr);
     rmConnection->SendCommand(cmd, registerParameter, msgnr);
 }
 
 void cResource::unregister1Resource(RMConnection *rmConnection, quint32 msgnr, QString unregisterParameter)
 {
     QString cmd = QString("RESOURCE:REMOVE");
-    m_msgNrList.append(msgnr);
+    m_msgNrListUnregister.append(msgnr);
     rmConnection->SendCommand(cmd, unregisterParameter, msgnr);
 }
 
 void cResource::resourceManagerAck(quint32 msgnr)
 {
-    if (m_msgNrList.removeOne(msgnr) && m_msgNrList.isEmpty())
+    if(m_msgNrListRegister.removeOne(msgnr) && m_msgNrListRegister.isEmpty())
         emit registerRdy();
+    if(m_msgNrListUnregister.removeOne(msgnr) && m_msgNrListUnregister.isEmpty())
+        emit unregisterRdy();
 }

--- a/zenux-service-common/lib/resources/resource.h
+++ b/zenux-service-common/lib/resources/resource.h
@@ -14,13 +14,16 @@ public:
     virtual ~cResource() = default;
     virtual void registerResource(RMConnection *rmConnection, quint16 port) = 0;
 signals:
-    void registerRdy(); // we emit signal when all register or unregister action is done
+    void registerRdy();
+    void unregisterRdy();
 public slots:
     void resourceManagerAck(quint32 msgnr);
 protected:
-    QList<quint32> m_msgNrList;
     void register1Resource(RMConnection *rmConnection, quint32 msgnr, QString registerParameter);
     void unregister1Resource(RMConnection *rmConnection, quint32 msgnr, QString unregisterParameter);
+private:
+    QList<quint32> m_msgNrListRegister;
+    QList<quint32> m_msgNrListUnregister;
 };
 
 #endif // RESOURCE_H

--- a/zenux-service-common/lib/resources/resourceregistertransaction.cpp
+++ b/zenux-service-common/lib/resources/resourceregistertransaction.cpp
@@ -12,12 +12,12 @@ void ResourceRegisterTransaction::register1Resource(QString registerParameter)
 {
     QString cmd = QString("RESOURCE:ADD");
     quint32 msgnr = NotZeroNumGen::getMsgNr();
-    m_msgNrList.append(msgnr);
+    m_msgNrListRegister.append(msgnr);
     m_rmConnection->SendCommand(cmd, registerParameter, msgnr);
 }
 
 void ResourceRegisterTransaction::resourceManagerAck(quint32 msgnr)
 {
-    if (m_msgNrList.removeOne(msgnr) && m_msgNrList.isEmpty())
-        emit registerDone();
+    if (m_msgNrListRegister.removeOne(msgnr) && m_msgNrListRegister.isEmpty())
+        emit registerRdy();
 }

--- a/zenux-service-common/lib/resources/resourceregistertransaction.h
+++ b/zenux-service-common/lib/resources/resourceregistertransaction.h
@@ -11,12 +11,12 @@ public:
     ResourceRegisterTransaction(RMConnection *rmConnection);
     void register1Resource(QString registerParameter);
 signals:
-    void registerDone();
+    void registerRdy();
 private slots:
     void resourceManagerAck(quint32 msgnr);
 private:
     RMConnection *m_rmConnection;
-    QList<quint32> m_msgNrList;
+    QList<quint32> m_msgNrListRegister;
 };
 
 #endif // RESOURCEREGISTERTRANSACTION_H

--- a/zenux-service-common/lib/scpi-interfaces/senseinterfacecommon.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/senseinterfacecommon.cpp
@@ -83,7 +83,6 @@ void SenseInterfaceCommon::computeSenseAdjData()
 
 void SenseInterfaceCommon::registerResource(RMConnection *rmConnection, quint16 port)
 {
-    m_msgNrList.clear();
     for(auto channel : qAsConst(m_channelList)) {
         register1Resource(rmConnection, NotZeroNumGen::getMsgNr(), QString("SENSE;%1;1;%2;%3;")
                                                                        .arg(channel->getName(), channel->getDescription())


### PR DESCRIPTION
* After recent refactoring zera-classes tests failed on developer's machines
* Ensure end detection connections are disconnected
* Introduce separate handling of resource add and remove to avoid surprises