### PR TITLE
core-log-services: Add "SEGV" to search strings

### DIFF
--- a/core-log-services/analysis-scripts/scripts/log_analysis.py
+++ b/core-log-services/analysis-scripts/scripts/log_analysis.py
@@ -3,7 +3,7 @@
 from optparse import OptionParser
 import glob, os
 
-key_strings_default = ["Failed with result 'core-dump'", "DSP stuck"]
+key_strings_default = ["Failed with result 'core-dump'", "DSP stuck", "SEGV"]
 limit_strings_default = [(" Memory used: ", 80)]
 
 class bcolors:

--- a/core-log-services/analysis-scripts/tests/test_logAnalysis.py
+++ b/core-log-services/analysis-scripts/tests/test_logAnalysis.py
@@ -24,7 +24,7 @@ class Test_logAnalysis(unittest.TestCase):
         self.assertEqual(check_strings(get_testFile(),["Failed with result 'core-dump'"])[0], 1205)
 
     def test_process_key_strings(self):
-        capturedOutput = process_key_strings(get_testFile())                                   
+        capturedOutput = process_key_strings(get_testFile(), ["Failed with result 'core-dump'", "DSP stuck"])
         expected_result = "Jun 24 13:25:07.409967 zera-mt310s2-unknown systemd[1]: modulemanager.service: Failed with result 'core-dump'."
         self.assertEqual(capturedOutput[3], expected_result)
          


### PR DESCRIPTION
extend analysis script to also search for key string "SEGV"