### PR TITLE
system-metrics-logger: rework totalmemorytracker and add unit display…

### DIFF
--- a/core-log-services/system-metrics-logger/app/main.cpp
+++ b/core-log-services/system-metrics-logger/app/main.cpp
@@ -9,7 +9,6 @@ int main( int argc, char *argv[] )
     std::unique_ptr<SystemMetrics> systemMetrics = std::make_unique<SystemMetrics>();
     systemMetrics->initLogComponents();
     systemMetrics->startLogComponentsTimer(1000);
-    systemMetrics->startMemoryPollTimer(10000);
 
     return app->exec();
 }

--- a/core-log-services/system-metrics-logger/lib/logstrategyminmaxmean.cpp
+++ b/core-log-services/system-metrics-logger/lib/logstrategyminmaxmean.cpp
@@ -1,7 +1,8 @@
 #include "logstrategyminmaxmean.h"
 
-LogStrategyMinMaxMean::LogStrategyMinMaxMean(QString valueLabel) :
-    m_valueLabel(valueLabel)
+LogStrategyMinMaxMean::LogStrategyMinMaxMean(QString valueLabel, QString unitLabel) :
+    m_valueLabel(valueLabel),
+    m_unitLabel(unitLabel)
 {
 }
 
@@ -12,8 +13,8 @@ void LogStrategyMinMaxMean::addValue(QList<float> &values, float newValue)
         float min = *std::min_element(values.begin(), values.end());
         float max = *std::max_element(values.begin(), values.end());
         float mean = std::accumulate(values.begin(), values.end(), 0.0)/values.size();
-        qInfo("%s min: %.1f, max: %.1f, mean: %.1f",
-              qPrintable(m_valueLabel), min, max, mean);
+        qInfo("%s (%s) min: %.1f, max: %.1f, mean: %.1f",
+              qPrintable(m_valueLabel), qPrintable(m_unitLabel), min, max, mean);
         values.clear();
     }
 }

--- a/core-log-services/system-metrics-logger/lib/logstrategyminmaxmean.h
+++ b/core-log-services/system-metrics-logger/lib/logstrategyminmaxmean.h
@@ -6,10 +6,11 @@
 class LogStrategyMinMaxMean : public AbstractLogStrategy
 {
 public:
-    LogStrategyMinMaxMean(QString valueLabel);
+    LogStrategyMinMaxMean(QString valueLabel, QString unitLabel);
     void addValue(QList<float> &values, float newValue) override;
 private:
     QString m_valueLabel;
+    QString m_unitLabel;
 };
 
 #endif // LOGSTRATEGYMINMAXMEAN_H

--- a/core-log-services/system-metrics-logger/lib/memoryvalues.h
+++ b/core-log-services/system-metrics-logger/lib/memoryvalues.h
@@ -8,6 +8,8 @@ struct MemoryValues {
     quint32 freeMemory = 0;
     quint32 buffers = 0;
     quint32 cached = 0;
+    quint32 sReclaimable = 0;
+    quint32 shmem = 0;
 };
 
 #endif // MEMORYVALUES_H

--- a/core-log-services/system-metrics-logger/lib/procmeminfodecoder.cpp
+++ b/core-log-services/system-metrics-logger/lib/procmeminfodecoder.cpp
@@ -15,6 +15,10 @@ MemoryValues ProcMeminfoDecoder::getCurrentMemoryValues()
             currentMemoryValues.buffers = decodeSingleMemoryValue(line);
         if(line.startsWith("Cached"))
             currentMemoryValues.cached = decodeSingleMemoryValue(line);
+        if(line.startsWith("SReclaimable"))
+            currentMemoryValues.sReclaimable = decodeSingleMemoryValue(line);
+        if(line.startsWith("Shmem"))
+            currentMemoryValues.shmem = decodeSingleMemoryValue(line);
     }
     return currentMemoryValues;
 }
@@ -25,6 +29,8 @@ QString ProcMeminfoDecoder::getProcMeminfo()
     QString procMeminfo;
     if(file.open(QFile::ReadOnly))
         procMeminfo = file.readAll();
+    else
+        qWarning("Cannot read meminfo file");
     return procMeminfo;
 }
 

--- a/core-log-services/system-metrics-logger/lib/systemmetrics.cpp
+++ b/core-log-services/system-metrics-logger/lib/systemmetrics.cpp
@@ -6,31 +6,10 @@
 
 #include <timerfactoryqt.h>
 
-TotalMemoryTracker *SystemMetrics::getTotalMemoryTracker()
-{
-    return &m_totalMemoryTracker;
-}
-
-void SystemMetrics::onMemoryTimer()
-{
-    m_totalMemoryTracker.calculateMemoryUsedPercent();
-    m_totalMemoryTracker.outputLogs();
-    emit sigNewMemValues();
-}
-
 void SystemMetrics::onLogComponentsTimer()
 {
     for(auto &entry : m_logComponents)
         entry->tryLogOne();
-}
-
-void SystemMetrics::startMemoryPollTimer(int logIntervalMs)
-{
-    m_memoryPollTimer = TimerFactoryQt::createPeriodic(logIntervalMs);
-    connect(m_memoryPollTimer.get(), &TimerTemplateQt::sigExpired,
-            this, &SystemMetrics::onMemoryTimer);
-    m_memoryPollTimer->start();
-    onMemoryTimer();
 }
 
 void SystemMetrics::startLogComponentsTimer(int pollMs)
@@ -48,19 +27,19 @@ void SystemMetrics::initLogComponents()
 
     currValueGetter = std::make_unique<CpuTemp>();
     if(currValueGetter->canGetValue())
-        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuTemp>(), std::make_unique<LogStrategyMinMaxMean>("CPU Temperature")));
+        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuTemp>(), std::make_unique<LogStrategyMinMaxMean>("CPU Temperature", "°C")));
     else
         qWarning("CpuTemp does not work in this environment - ignore!");
 
     currValueGetter = std::make_unique<CpuLoad>(0);
     if(currValueGetter->canGetValue())
-        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuLoad>(0), std::make_unique<LogStrategyMinMaxMean>("CPU Load")));
+        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuLoad>(0), std::make_unique<LogStrategyMinMaxMean>("CPU Load", "%")));
     else
         qWarning("CpuLoad does not work in this environment - ignore");
 
     currValueGetter = std::make_unique<CpuFreq>();
     if(currValueGetter->canGetValue())
-        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuFreq>(), std::make_unique<LogStrategyMinMaxMean>("CPU Frequency")));
+        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuFreq>(), std::make_unique<LogStrategyMinMaxMean>("CPU Frequency", "MHz")));
     else
         qWarning("CpuFrequency does not work in this environment - ignore");
 }

--- a/core-log-services/system-metrics-logger/lib/systemmetrics.cpp
+++ b/core-log-services/system-metrics-logger/lib/systemmetrics.cpp
@@ -3,6 +3,7 @@
 #include "cpuload.h"
 #include "cpufreq.h"
 #include "logstrategyminmaxmean.h"
+#include "totalmemorytracker.h"
 
 #include <timerfactoryqt.h>
 
@@ -42,4 +43,10 @@ void SystemMetrics::initLogComponents()
         m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<CpuFreq>(), std::make_unique<LogStrategyMinMaxMean>("CPU Frequency", "MHz")));
     else
         qWarning("CpuFrequency does not work in this environment - ignore");
+
+    currValueGetter = std::make_unique<TotalMemoryTracker>();
+    if(currValueGetter->canGetValue())
+        m_logComponents.push_back(std::make_unique<LogComponent>(std::make_unique<TotalMemoryTracker>(), std::make_unique<LogStrategyMinMaxMean>("RAM usage", "%")));
+    else
+        qWarning("RAM usage does not work in this environment - ignore");
 }

--- a/core-log-services/system-metrics-logger/lib/systemmetrics.h
+++ b/core-log-services/system-metrics-logger/lib/systemmetrics.h
@@ -1,7 +1,6 @@
 #ifndef SYSTEMMETRICS_H
 #define SYSTEMMETRICS_H
 
-#include "totalmemorytracker.h"
 #include "logcomponent.h"
 #include <timertemplateqt.h>
 #include <QObject>
@@ -11,20 +10,12 @@ class SystemMetrics : public QObject
 {
     Q_OBJECT
 public:
-    TotalMemoryTracker *getTotalMemoryTracker();
-    void startMemoryPollTimer(int logIntervalMs);
     void startLogComponentsTimer(int pollMs);
     void initLogComponents();
-signals:
-    void sigNewCpuValues();
-    void sigNewMemValues();
 
 private slots:
-    void onMemoryTimer();
     void onLogComponentsTimer();
 private:
-    TimerTemplateQtPtr m_memoryPollTimer;
-    TotalMemoryTracker m_totalMemoryTracker;
 
     // new style??
     std::vector<std::unique_ptr<LogComponent>> m_logComponents;

--- a/core-log-services/system-metrics-logger/lib/totalmemorytracker.h
+++ b/core-log-services/system-metrics-logger/lib/totalmemorytracker.h
@@ -1,25 +1,16 @@
 #ifndef TOTALMEMORYTRACKER_H
 #define TOTALMEMORYTRACKER_H
 
-#include <QMap>
+#include "abstractlogvaluegetter.h"
 
-struct MemoryUsageParams {
-    float m_RAMUsedPercent = 0.0;
-    float m_cachesUsedPercent = 0.0;
-    float m_buffersUsedPercent = 0.0;
-    void setZeros();
-};
-
-class TotalMemoryTracker
+class TotalMemoryTracker : public AbstractLogValueGetter
 {
 public:
-    void calculateMemoryUsedPercent();
-    MemoryUsageParams getMemoryUsageParams() const;
-    void outputLogs();
+    bool canGetValue() override;
+    float getValue() override;
+
 private:
     float calcPercentageOneDecimal(float value);
-    MemoryUsageParams m_memoryUsageParams;
-    QString m_lastLogString;
 };
 
 #endif // TOTALMEMORYTRACKER_H

--- a/core-log-services/system-metrics-logger/tests/test-data/procMeminfoAllZero
+++ b/core-log-services/system-metrics-logger/tests/test-data/procMeminfoAllZero
@@ -3,3 +3,5 @@ MemFree:          0 kB
 MemAvailable:     0 kB
 Buffers:          0 kB
 Cached:           0 kB
+Shmem:             0 kB
+SReclaimable:      0 kB

--- a/core-log-services/system-metrics-logger/tests/test_cputemp.cpp
+++ b/core-log-services/system-metrics-logger/tests/test_cputemp.cpp
@@ -28,7 +28,7 @@ void test_cputemp::test_invalidDirectory()
 void test_cputemp::test_logComponent()
 {
     TestSystemInfoFileLocator::setSysTempRootPath(":/");
-    LogComponent temperatureComponent(std::make_unique<CpuTemp>(), std::make_unique<LogStrategyMinMaxMean>("foo"));
+    LogComponent temperatureComponent(std::make_unique<CpuTemp>(), std::make_unique<LogStrategyMinMaxMean>("foo", "°C"));
     temperatureComponent.tryLogOne();
     QList<float> test(temperatureComponent.getBuffer());
 
@@ -38,7 +38,7 @@ void test_cputemp::test_logComponent()
 void test_cputemp::test_logComponentEmptyAfterTen()
 {
     TestSystemInfoFileLocator::setSysTempRootPath(":/");
-    LogComponent temperatureComponent(std::make_unique<CpuTemp>(), std::make_unique<LogStrategyMinMaxMean>("foo"));
+    LogComponent temperatureComponent(std::make_unique<CpuTemp>(), std::make_unique<LogStrategyMinMaxMean>("foo", "°C"));
     for(int i = 0; i < 10; i++)
         temperatureComponent.tryLogOne();
     QList<float> test(temperatureComponent.getBuffer());

--- a/core-log-services/system-metrics-logger/tests/test_totalmemorytracker.cpp
+++ b/core-log-services/system-metrics-logger/tests/test_totalmemorytracker.cpp
@@ -5,22 +5,17 @@
 
 QTEST_MAIN(test_totalmemorytracker)
 
-void test_totalmemorytracker::test_initial_zero()
+void test_totalmemorytracker::test_invalid_values()
 {
-    TotalMemoryTracker memorytracker;
-    TestSystemInfoFileLocator::setProcMeminfoFileName(":/procMeminfoAllZero");
-    memorytracker.calculateMemoryUsedPercent();
-    QCOMPARE(memorytracker.getMemoryUsageParams().m_RAMUsedPercent, 0.0);
-    QCOMPARE(memorytracker.getMemoryUsageParams().m_buffersUsedPercent, 0.0);
-    QCOMPARE(memorytracker.getMemoryUsageParams().m_cachesUsedPercent, 0.0);
+    TotalMemoryTracker memoryTracker;
+    TestSystemInfoFileLocator::setProcMeminfoFileName(":/procMeminfAllZero");
+    QCOMPARE(memoryTracker.canGetValue(), false);
 }
 
-void test_totalmemorytracker::testMemoryUsed()
+void test_totalmemorytracker::test_memory_used()
 {
-    TotalMemoryTracker memorytracker;
+    TotalMemoryTracker memoryTracker;
     TestSystemInfoFileLocator::setProcMeminfoFileName(":/procMeminfo");
-    memorytracker.calculateMemoryUsedPercent();
-    QCOMPARE(memorytracker.getMemoryUsageParams().m_RAMUsedPercent, 25.0);
-    QCOMPARE(memorytracker.getMemoryUsageParams().m_buffersUsedPercent, 15.0);
-    QCOMPARE(memorytracker.getMemoryUsageParams().m_cachesUsedPercent, 20.0);
+    QCOMPARE(memoryTracker.canGetValue(), true);
+    QCOMPARE((int)memoryTracker.getValue(), 27);
 }

--- a/core-log-services/system-metrics-logger/tests/test_totalmemorytracker.h
+++ b/core-log-services/system-metrics-logger/tests/test_totalmemorytracker.h
@@ -7,8 +7,8 @@ class test_totalmemorytracker : public QObject
 {
     Q_OBJECT
 private slots:
-    void test_initial_zero();
-    void testMemoryUsed();
+    void test_invalid_values();
+    void test_memory_used();
 };
 
 #endif // TEST_TOTALMEMORYTRACKER_H


### PR DESCRIPTION
… to logger

- totalmemorytracker now mimics htop memory usage, but in percent
- log messages in the "new" style can now have units attached