### PR TITLE
Make injecting of tcp worker factory mandatory on all servers around

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ function(SETUP_TESTS)
             Zera::zera-timers-testlib
             Zera::zera-i2c-devices-testlib
             Zera::resman-lib
+            Zera::vf-tcp-mock-networklib
             )
     endforeach()
 endfunction()

--- a/com5003d/lib/com5003d.cpp
+++ b/com5003d/lib/com5003d.cpp
@@ -35,16 +35,6 @@ const ServerParams cCOM5003dServer::defaultParams {ServerName, ServerVersion, "/
 
 cCOM5003dServer::cCOM5003dServer(SettingsContainerPtr settings,
                                  AbstractFactoryI2cCtrlPtr ctrlFactory,
-                                 AbstractFactoryDeviceNodePcbPtr deviceNodeFactory) :
-    PCBServer(std::move(settings), ScpiSingletonFactory::getScpiObj()),
-    m_ctrlFactory(ctrlFactory),
-    m_deviceNodeFactory(deviceNodeFactory)
-{
-    init();
-}
-
-cCOM5003dServer::cCOM5003dServer(SettingsContainerPtr settings,
-                                 AbstractFactoryI2cCtrlPtr ctrlFactory,
                                  AbstractFactoryDeviceNodePcbPtr deviceNodeFactory,
                                  VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
     PCBServer(std::move(settings), ScpiSingletonFactory::getScpiObj(), tcpWorkerFactory),

--- a/com5003d/lib/com5003d.h
+++ b/com5003d/lib/com5003d.h
@@ -34,9 +34,6 @@ class cCOM5003dServer: public PCBServer
 public:
     explicit cCOM5003dServer(SettingsContainerPtr settings,
                              AbstractFactoryI2cCtrlPtr ctrlFactory,
-                             AbstractFactoryDeviceNodePcbPtr deviceNodeFactory);
-    explicit cCOM5003dServer(SettingsContainerPtr settings,
-                             AbstractFactoryI2cCtrlPtr ctrlFactory,
                              AbstractFactoryDeviceNodePcbPtr deviceNodeFactory,
                              VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     ~cCOM5003dServer();

--- a/com5003d/main.cpp
+++ b/com5003d/main.cpp
@@ -2,6 +2,7 @@
 #include "com5003dglobal.h"
 #include "factorydevicenodepcb.h"
 #include "factoryi2cctrl.h"
+#include <tcpworkerfactory.h>
 #include <QCoreApplication>
 
 int main( int argc, char *argv[] )
@@ -13,7 +14,8 @@ int main( int argc, char *argv[] )
     cCOM5003dServer* com5003d = new cCOM5003dServer(
         std::move(settings),
         ctrlFactory,
-        std::make_shared<FactoryDeviceNodePcb>());
+        std::make_shared<FactoryDeviceNodePcb>(),
+        VeinTcp::TcpWorkerFactory::create());
     qInfo(ServerName " started");
 
     int r = app->exec();

--- a/com5003d/testlib/testserverforsenseinterfacecom5003.cpp
+++ b/com5003d/testlib/testserverforsenseinterfacecom5003.cpp
@@ -2,8 +2,10 @@
 #include "com5003senseinterface.h"
 #include "testsysteminfo.h"
 
-TestServerForSenseInterfaceCom5003::TestServerForSenseInterfaceCom5003(AbstractFactoryI2cCtrlPtr ctrlFactory, bool systemInfoMock) :
-    TestPcbServer("com5003d")
+TestServerForSenseInterfaceCom5003::TestServerForSenseInterfaceCom5003(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                                                                       VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                                                       bool systemInfoMock) :
+    TestPcbServer("com5003d", tcpWorkerFactory)
 {
     if(systemInfoMock)
         m_systemInfo = std::make_unique<TestSystemInfo>(ctrlFactory);

--- a/com5003d/testlib/testserverforsenseinterfacecom5003.h
+++ b/com5003d/testlib/testserverforsenseinterfacecom5003.h
@@ -11,7 +11,9 @@
 class TestServerForSenseInterfaceCom5003  : public TestPcbServer
 {
 public:
-    TestServerForSenseInterfaceCom5003(AbstractFactoryI2cCtrlPtr ctrlFactory, bool systemInfoMock = false);
+    TestServerForSenseInterfaceCom5003(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                                       VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                       bool systemInfoMock = false);
     QString getDeviceVersion() { return m_systemInfo->getDeviceVersion(); }
     SenseInterfaceCommon *getSenseInterface() { return m_senseInterface.get(); }
     cSenseSettings* getSenseSettings() { return m_senseSettings.get(); }

--- a/com5003d/tests/test_adj_deny_import_com5003.cpp
+++ b/com5003d/tests/test_adj_deny_import_com5003.cpp
@@ -10,6 +10,7 @@
 #include "xmlhelperfortest.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_adj_deny_import_com5003);
@@ -62,9 +63,11 @@ void test_adj_deny_import_com5003::loadEEpromAndDenyDifferentDeviceName()
 
 void test_adj_deny_import_com5003::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
     m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true),
-                                                                  true);
+                                                                        tcpWorkerFactory,
+                                                                        true);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_adj_calc_com5003.cpp
+++ b/com5003d/tests/test_regression_adj_calc_com5003.cpp
@@ -5,6 +5,7 @@
 #include "mockeeprom24lc.h"
 #include "scpisingletransactionblocked.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -79,8 +80,9 @@ void test_regression_adj_calc_com5003::offsetAdjValueTotal()
 
 void test_regression_adj_calc_com5003::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_adj_import_export_eeprom_com5003.cpp
+++ b/com5003d/tests/test_regression_adj_import_export_eeprom_com5003.cpp
@@ -10,6 +10,7 @@
 #include "xmlhelperfortest.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -178,8 +179,9 @@ void test_regression_adj_import_export_eeprom_com5003::loadArbitraryVersionToEEp
 
 void test_regression_adj_import_export_eeprom_com5003::setupServers(AbstractFactoryI2cCtrlPtr ctrlFactory)
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(ctrlFactory);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(ctrlFactory, tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_adj_import_export_xml_com5003.cpp
+++ b/com5003d/tests/test_regression_adj_import_export_xml_com5003.cpp
@@ -5,6 +5,7 @@
 #include "testfactoryi2cctrl.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -112,8 +113,9 @@ void test_regression_adj_import_export_xml_com5003::scpiExportInitialAdjXml()
 
 void test_regression_adj_import_export_xml_com5003::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_adj_import_permission_com5003.cpp
+++ b/com5003d/tests/test_regression_adj_import_permission_com5003.cpp
@@ -7,6 +7,7 @@
 #include "xmlhelperfortest.h"
 #include "mocki2ceepromiofactory.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -73,8 +74,9 @@ void test_regression_adj_import_permission_com5003::scpiImportPassFlashWrite()
 
 void test_regression_adj_import_permission_com5003::setupServers(AbstractFactoryI2cCtrlPtr ctrlFactory)
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(ctrlFactory);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(ctrlFactory, tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_adj_scpi_query_format_com5003.cpp
+++ b/com5003d/tests/test_regression_adj_scpi_query_format_com5003.cpp
@@ -5,6 +5,7 @@
 #include "mockeeprom24lc.h"
 #include "scpisingletransactionblocked.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -264,8 +265,9 @@ void test_regression_adj_scpi_query_format_com5003::queryOffsetNodes()
 
 void test_regression_adj_scpi_query_format_com5003::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_adj_status_com5003.cpp
+++ b/com5003d/tests/test_regression_adj_status_com5003.cpp
@@ -5,9 +5,9 @@
 #include "scpisingletransactionblocked.h"
 #include "mocki2ceepromiofactory.h"
 #include "testfactoryi2cctrl.h"
-#include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
 #include <mockeeprom24lc.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_regression_adj_status_com5003);
@@ -57,8 +57,9 @@ void test_regression_adj_status_com5003::setupServers(AbstractFactoryI2cCtrlPtr 
 {
     PermissionFunctions::setPermissionCtrlFactory(ctrlFactory);
 
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(ctrlFactory);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(ctrlFactory, tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_critical_status_com5003.cpp
+++ b/com5003d/tests/test_regression_critical_status_com5003.cpp
@@ -4,6 +4,7 @@
 #include "proxy.h"
 #include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_regression_critical_status_com5003);
@@ -102,8 +103,10 @@ void test_regression_critical_status_com5003::resetM5()
 
 void test_regression_critical_status_com5003::setupServers(quint16 initialCriticalStatus)
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrlCriticalStatus>(initialCriticalStatus));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrlCriticalStatus>(initialCriticalStatus),
+                                                                        tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/com5003d/tests/test_regression_sense_interface_com5003.cpp
+++ b/com5003d/tests/test_regression_sense_interface_com5003.cpp
@@ -5,6 +5,7 @@
 #include "proxy.h"
 #include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QRegularExpression>
 #include <QJsonValue>
 #include <QJsonDocument>
@@ -15,8 +16,9 @@ QTEST_MAIN(test_regression_sense_interface_com5003);
 
 void test_regression_sense_interface_com5003::init()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/lib/mt310s2d.cpp
+++ b/mt310s2d/lib/mt310s2d.cpp
@@ -45,16 +45,6 @@ const ServerParams cMT310S2dServer::defaultParams {ServerName, ServerVersion, "/
 
 cMT310S2dServer::cMT310S2dServer(SettingsContainerPtr settings,
                                  AbstractFactoryI2cCtrlPtr ctrlFactory,
-                                 AbstractFactoryDeviceNodePcbPtr deviceNodeFactory) :
-    PCBServer(std::move(settings), ScpiSingletonFactory::getScpiObj()),
-    m_ctrlFactory(ctrlFactory),
-    m_deviceNodeFactory(deviceNodeFactory)
-{
-    init();
-}
-
-cMT310S2dServer::cMT310S2dServer(SettingsContainerPtr settings,
-                                 AbstractFactoryI2cCtrlPtr ctrlFactory,
                                  AbstractFactoryDeviceNodePcbPtr deviceNodeFactory,
                                  VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
     PCBServer(std::move(settings), ScpiSingletonFactory::getScpiObj(), tcpWorkerFactory),

--- a/mt310s2d/lib/mt310s2d.h
+++ b/mt310s2d/lib/mt310s2d.h
@@ -34,9 +34,6 @@ class cMT310S2dServer: public PCBServer
 public:
     explicit cMT310S2dServer(SettingsContainerPtr settings,
                              AbstractFactoryI2cCtrlPtr ctrlFactory,
-                             AbstractFactoryDeviceNodePcbPtr deviceNodeFactory);
-    explicit cMT310S2dServer(SettingsContainerPtr settings,
-                             AbstractFactoryI2cCtrlPtr ctrlFactory,
                              AbstractFactoryDeviceNodePcbPtr deviceNodeFactory,
                              VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     ~cMT310S2dServer();

--- a/mt310s2d/main.cpp
+++ b/mt310s2d/main.cpp
@@ -2,6 +2,7 @@
 #include "mt310s2dglobal.h"
 #include "factoryi2cctrl.h"
 #include "factorydevicenodepcb.h"
+#include <tcpworkerfactory.h>
 #include <QCoreApplication>
 
 int main( int argc, char *argv[] )
@@ -13,7 +14,8 @@ int main( int argc, char *argv[] )
     cMT310S2dServer* mt310s2d = new cMT310S2dServer(
         std::move(settings),
         ctrlFactory,
-        std::make_shared<FactoryDeviceNodePcb>());
+        std::make_shared<FactoryDeviceNodePcb>(),
+        VeinTcp::TcpWorkerFactory::create());
     qInfo(ServerName " started");
 
     int r = app->exec();

--- a/mt310s2d/testlib/testserverforsenseinterfacemt310s2.cpp
+++ b/mt310s2d/testlib/testserverforsenseinterfacemt310s2.cpp
@@ -4,8 +4,10 @@
 #include "mt310s2systeminfomock.h"
 #include <i2cmultiplexerfactory.h>
 
-TestServerForSenseInterfaceMt310s2::TestServerForSenseInterfaceMt310s2(AbstractFactoryI2cCtrlPtr ctrlFactory, bool systemInfoMock) :
-    TestPcbServer("mt310s2d")
+TestServerForSenseInterfaceMt310s2::TestServerForSenseInterfaceMt310s2(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                                                                       VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                                                       bool systemInfoMock) :
+    TestPcbServer("mt310s2d", tcpWorkerFactory)
 {
     m_senseSettings = std::make_unique<cSenseSettings>(getConfigReader(), 8);
     setXmlSettings(XmlSettingsList{m_senseSettings.get()});

--- a/mt310s2d/testlib/testserverforsenseinterfacemt310s2.h
+++ b/mt310s2d/testlib/testserverforsenseinterfacemt310s2.h
@@ -10,7 +10,9 @@
 class TestServerForSenseInterfaceMt310s2 : public TestPcbServer
 {
 public:
-    TestServerForSenseInterfaceMt310s2(AbstractFactoryI2cCtrlPtr ctrlFactory, bool systemInfoMock = false);
+    TestServerForSenseInterfaceMt310s2(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                                       VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                       bool systemInfoMock = false);
     QString getDeviceVersion() { return m_systemInfo->getDeviceVersion(); }
 
     SenseInterfaceCommon *getSenseInterface() { return m_senseInterface.get(); }

--- a/mt310s2d/tests/test_accumulatorinterface_mock.cpp
+++ b/mt310s2d/tests/test_accumulatorinterface_mock.cpp
@@ -5,7 +5,7 @@
 #include <timemachineobject.h>
 #include <timerfactoryqtfortest.h>
 #include <timemachinefortest.h>
-
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -99,8 +99,9 @@ void test_accumulatorinterface_mock::readAccuStateOfChargeAccuEnabled()
 
 void test_accumulatorinterface_mock::setupServers(QString configFileXml)
 {
-    m_resman = std::make_unique<ResmanRunFacade>();
-    m_mt310s2d = std::make_unique<MockMt310s2d>(std::make_shared<TestFactoryI2cCtrl>(true), configFileXml);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resman = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_mt310s2d = std::make_unique<MockMt310s2d>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory, configFileXml);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_adj_deny_import_mt310s2.cpp
+++ b/mt310s2d/tests/test_adj_deny_import_mt310s2.cpp
@@ -10,6 +10,7 @@
 #include "xmlhelperfortest.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_adj_deny_import_mt310s2);
@@ -63,9 +64,11 @@ void test_adj_deny_import_mt310s2::loadEEpromAndDenyDifferentDeviceName()
 
 void test_adj_deny_import_mt310s2::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
     m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true),
-                                                                  true);
+                                                                        tcpWorkerFactory,
+                                                                        true);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_adj_calc_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_adj_calc_mt310s2.cpp
@@ -8,6 +8,7 @@
 #include "scpisingletransactionblocked.h"
 #include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -151,8 +152,9 @@ void test_regression_adj_calc_mt310s2::offsetAdjValueTotalClamp()
 
 void test_regression_adj_calc_mt310s2::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_adj_import_export_eeprom_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_adj_import_export_eeprom_mt310s2.cpp
@@ -11,6 +11,7 @@
 #include "xmlhelperfortest.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -253,8 +254,9 @@ void test_regression_adj_import_export_eeprom_mt310s2::freshClampSetTypeUIEeprom
 
 void test_regression_adj_import_export_eeprom_mt310s2::setupServers(AbstractFactoryI2cCtrlPtr ctrlFactory)
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory, tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_adj_import_export_xml_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_adj_import_export_xml_mt310s2.cpp
@@ -6,6 +6,7 @@
 #include "xmlhelperfortest.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -178,8 +179,9 @@ void test_regression_adj_import_export_xml_mt310s2::scpiExportInvalidClamp()
 
 void test_regression_adj_import_export_xml_mt310s2::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_adj_import_permission_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_adj_import_permission_mt310s2.cpp
@@ -7,6 +7,7 @@
 #include "xmlhelperfortest.h"
 #include "mocki2ceepromiofactory.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -73,8 +74,9 @@ void test_regression_adj_import_permission_mt310s2::scpiImportPassFlashWrite()
 
 void test_regression_adj_import_permission_mt310s2::setupServers(AbstractFactoryI2cCtrlPtr ctrlFactory)
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory, tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_adj_scpi_query_format_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_adj_scpi_query_format_mt310s2.cpp
@@ -5,6 +5,7 @@
 #include "scpisingletransactionblocked.h"
 #include "testfactoryi2cctrl.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -263,8 +264,9 @@ void test_regression_adj_scpi_query_format_mt310s2::queryOffsetNodes()
 
 void test_regression_adj_scpi_query_format_mt310s2::setupServers()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_adj_status_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_adj_status_mt310s2.cpp
@@ -9,6 +9,7 @@
 #include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
 #include <mockeeprom24lc.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_regression_adj_status_mt310s2);
@@ -76,8 +77,9 @@ void test_regression_adj_status_mt310s2::setupServers(AbstractFactoryI2cCtrlPtr 
 {
     PermissionFunctions::setPermissionCtrlFactory(ctrlFactory);
 
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory, tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_critical_status_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_critical_status_mt310s2.cpp
@@ -4,6 +4,7 @@
 #include "proxy.h"
 #include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_regression_critical_status_mt310s2);
@@ -143,8 +144,9 @@ void test_regression_critical_status_mt310s2::resetM7()
 
 void test_regression_critical_status_mt310s2::setupServers(quint16 initialCriticalStatus)
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrlCriticalStatus>(initialCriticalStatus));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrlCriticalStatus>(initialCriticalStatus), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/mt310s2d/tests/test_regression_sense_interface_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_sense_interface_mt310s2.cpp
@@ -7,6 +7,7 @@
 #include "zscpi_response_definitions.h"
 #include <i2cmultiplexerfactory.h>
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QFile>
 #include <QRegularExpression>
 #include <QJsonValue>
@@ -19,8 +20,9 @@ QTEST_MAIN(test_regression_sense_interface_mt310s2);
 void test_regression_sense_interface_mt310s2::initTestCase()
 {
     ClampFactoryTest::enableTest();
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/sec1000d/lib/sec1000d.cpp
+++ b/sec1000d/lib/sec1000d.cpp
@@ -39,14 +39,6 @@ struct sigaction sigActionSec1000;
 const ServerParams cSEC1000dServer::defaultParams{ServerName, ServerVersion, "/etc/zera/sec1000d/sec1000d.xsd", "/etc/zera/sec1000d/sec1000d.xml"};
 
 cSEC1000dServer::cSEC1000dServer(SettingsContainerPtr settings,
-                                 AbstractFactoryDeviceNodeSecPtr deviceNodeFactory) :
-    PCBServer(std::move(settings), ScpiSingletonFactory::getScpiObj()),
-    m_deviceNodeFactory(deviceNodeFactory)
-{
-    init();
-}
-
-cSEC1000dServer::cSEC1000dServer(SettingsContainerPtr settings,
                                  AbstractFactoryDeviceNodeSecPtr deviceNodeFactory,
                                  VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
     PCBServer(std::move(settings), ScpiSingletonFactory::getScpiObj(), tcpWorkerFactory),

--- a/sec1000d/lib/sec1000d.h
+++ b/sec1000d/lib/sec1000d.h
@@ -23,7 +23,6 @@ class cSEC1000dServer: public PCBServer
 {
     Q_OBJECT
 public:
-    explicit cSEC1000dServer(SettingsContainerPtr settings, AbstractFactoryDeviceNodeSecPtr deviceNodeFactory);
     explicit cSEC1000dServer(SettingsContainerPtr settings, AbstractFactoryDeviceNodeSecPtr deviceNodeFactory,
                              VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     ~cSEC1000dServer();

--- a/sec1000d/main.cpp
+++ b/sec1000d/main.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QTextCodec>
 #include "factorydevicenodesec.h"
+#include <tcpworkerfactory.h>
 #include "sec1000d.h"
 
 int main( int argc, char *argv[] )
@@ -13,7 +14,8 @@ int main( int argc, char *argv[] )
 
     cSEC1000dServer* sec5003d = new cSEC1000dServer(
         std::make_unique<SettingsContainer>(cSEC1000dServer::defaultParams),
-        std::make_shared<FactoryDeviceNodeSec>());
+        std::make_shared<FactoryDeviceNodeSec>(),
+        VeinTcp::TcpWorkerFactory::create());
     qInfo("%s started", qPrintable(sec5003d->getServerVersion()));
 
     int r = app->exec();

--- a/zdsp1d/lib/zdspserver.cpp
+++ b/zdsp1d/lib/zdspserver.cpp
@@ -56,17 +56,6 @@ struct sigaction sigActionZdsp1;
 
 const ServerParams ZDspServer::defaultParams {ServerName, ServerVersion, "/etc/zera/zdsp1d/zdsp1d.xsd", "/etc/zera/zdsp1d/zdsp1d.xml"};
 
-ZDspServer::ZDspServer(SettingsContainerPtr settings, AbstractFactoryDeviceNodeDspPtr deviceNodeFactory) :
-    ScpiConnection(ScpiSingletonFactory::getScpiObj()),
-    m_deviceNodeFactory(deviceNodeFactory),
-    m_settings(std::move(settings)),
-    m_dspInterruptLogStatistics(10000),
-    m_pRMConnection(new RMConnection(m_settings->getEthSettings()->getRMIPadr(), m_settings->getEthSettings()->getPort(EthSettings::resourcemanager))),
-    m_resourceRegister(m_pRMConnection)
-{
-    init();
-}
-
 ZDspServer::ZDspServer(SettingsContainerPtr settings,
                        AbstractFactoryDeviceNodeDspPtr deviceNodeFactory,
                        VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :

--- a/zdsp1d/lib/zdspserver.h
+++ b/zdsp1d/lib/zdspserver.h
@@ -33,8 +33,8 @@ class ZDspServer: public ScpiConnection, public cbIFace
 {
     Q_OBJECT
 public:
-    ZDspServer(SettingsContainerPtr settings, AbstractFactoryDeviceNodeDspPtr deviceNodeFactory);
-    ZDspServer(SettingsContainerPtr settings, AbstractFactoryDeviceNodeDspPtr deviceNodeFactory,
+    ZDspServer(SettingsContainerPtr settings,
+               AbstractFactoryDeviceNodeDspPtr deviceNodeFactory,
                VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     virtual ~ZDspServer();
     void initSCPIConnection(QString leadingNodes) override;

--- a/zdsp1d/main.cpp
+++ b/zdsp1d/main.cpp
@@ -1,6 +1,7 @@
 #include "zdspserver.h"
 #include "pcbserver.h"
 #include "factorydevicenodedsp.h"
+#include <tcpworkerfactory.h>
 #include <QCoreApplication>
 
 int main( int argc, char *argv[] )
@@ -9,7 +10,8 @@ int main( int argc, char *argv[] )
 
     ZDspServer* zdsp1d = new ZDspServer(
         std::make_unique<SettingsContainer>(ZDspServer::defaultParams),
-        std::make_shared<FactoryDeviceNodeDsp>());
+        std::make_shared<FactoryDeviceNodeDsp>(),
+        VeinTcp::TcpWorkerFactory::create());
     qInfo("%s started", qPrintable(zdsp1d->getServerVersion()));
 
     int r =  app->exec();

--- a/zdsp1d/tests/test_regression_dsp_var.cpp
+++ b/zdsp1d/tests/test_regression_dsp_var.cpp
@@ -7,6 +7,7 @@
 #include "testsingletondevicenodedsp.h"
 #include "dspinterfacecmddecoder.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -16,8 +17,9 @@ static constexpr quint16 dspServerPort = 6310;
 
 void test_regression_dsp_var::init()
 {
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_dspService = std::make_unique<MockZdsp1d>(std::make_shared<TestFactoryDeviceNodeDsp>());
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_dspService = std::make_unique<MockZdsp1d>(std::make_shared<TestFactoryDeviceNodeDsp>(), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", dspServerPort);

--- a/zenux-service-common/demolib/demoallservicescom5003.cpp
+++ b/zenux-service-common/demolib/demoallservicescom5003.cpp
@@ -3,14 +3,26 @@
 #include "demoeventloopfeeder.h"
 #include "demofactorydevicenodedsp.h"
 #include "mockserverparamgenerator.h"
+#include <tcpworkerfactory.h>
 
 DemoAllServicesCom5003::DemoAllServicesCom5003()
 {
-    m_resman = new ResmanRunFacade;
+    // for now default to real network
+    init(VeinTcp::TcpWorkerFactory::create());
+}
+
+DemoAllServicesCom5003::DemoAllServicesCom5003(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory)
+{
+    init(tcpWorkerFactory);
+}
+
+void DemoAllServicesCom5003::init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory)
+{
+    m_resman = new ResmanRunFacade(tcpWorkerFactory);
     ServerParams params = MockServerParamGenerator::createParams("com5003d");
-    m_mockcom5003d = new MockCom5003d(std::make_shared<DemoFactoryI2cCtrl>(std::make_unique<SettingsContainer>(params)));
-    m_sec1000d = new MockSec1000d;
-    m_zdsp1d = new MockZdsp1d(std::make_shared<DemoFactoryDeviceNodeDsp>());
+    m_mockcom5003d = new MockCom5003d(std::make_shared<DemoFactoryI2cCtrl>(std::make_unique<SettingsContainer>(params)), tcpWorkerFactory);
+    m_sec1000d = new MockSec1000d(tcpWorkerFactory);
+    m_zdsp1d = new MockZdsp1d(std::make_shared<DemoFactoryDeviceNodeDsp>(), tcpWorkerFactory);
     DemoEventLoopFeeder::feedEventLoop();
 #ifdef GUI_SIMULATION
     m_gui = new SimulQmlGui;

--- a/zenux-service-common/demolib/demoallservicescom5003.h
+++ b/zenux-service-common/demolib/demoallservicescom5003.h
@@ -14,8 +14,11 @@ class DemoAllServicesCom5003 : public AbstractMockAllServices
 {
 public:
     DemoAllServicesCom5003();
+    DemoAllServicesCom5003(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     virtual ~DemoAllServicesCom5003();
+
 private:
+    void init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     ResmanRunFacade *m_resman;
     MockCom5003d *m_mockcom5003d;
     MockSec1000d *m_sec1000d;

--- a/zenux-service-common/demolib/demoallservicesmt310s2.cpp
+++ b/zenux-service-common/demolib/demoallservicesmt310s2.cpp
@@ -4,15 +4,27 @@
 #include "demofactorydevicenodedsp.h"
 #include "mockserverparamgenerator.h"
 #include "autojournalloggerfacade.h"
+#include <tcpworkerfactory.h>
 
 DemoAllServicesMt310s2::DemoAllServicesMt310s2()
 {
+    // for now default to real network
+    init(VeinTcp::TcpWorkerFactory::create());
+}
+
+DemoAllServicesMt310s2::DemoAllServicesMt310s2(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory)
+{
+    init(tcpWorkerFactory);
+}
+
+void DemoAllServicesMt310s2::init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory)
+{
     m_autoLogger = new AutoJournalLoggerFacade;
-    m_resman = new ResmanRunFacade;
+    m_resman = new ResmanRunFacade(tcpWorkerFactory);
     ServerParams params = MockServerParamGenerator::createParams("mt310s2d");
-    m_mt310s2d = new MockMt310s2d(std::make_shared<DemoFactoryI2cCtrl>(std::make_unique<SettingsContainer>(params)));
-    m_sec1000d = new MockSec1000d;
-    m_zdsp1d = new MockZdsp1d(std::make_shared<DemoFactoryDeviceNodeDsp>());
+    m_mt310s2d = new MockMt310s2d(std::make_shared<DemoFactoryI2cCtrl>(std::make_unique<SettingsContainer>(params)), tcpWorkerFactory);
+    m_sec1000d = new MockSec1000d(tcpWorkerFactory);
+    m_zdsp1d = new MockZdsp1d(std::make_shared<DemoFactoryDeviceNodeDsp>(), tcpWorkerFactory);
     DemoEventLoopFeeder::feedEventLoop();
 #ifdef GUI_SIMULATION
     m_gui = new SimulQmlGui;

--- a/zenux-service-common/demolib/demoallservicesmt310s2.h
+++ b/zenux-service-common/demolib/demoallservicesmt310s2.h
@@ -16,8 +16,11 @@ class DemoAllServicesMt310s2 : public AbstractMockAllServices
 {
 public:
     DemoAllServicesMt310s2();
+    DemoAllServicesMt310s2(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     virtual ~DemoAllServicesMt310s2();
+
 private:
+    void init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     AutoJournalLoggerFacade *m_autoLogger;
     ResmanRunFacade *m_resman;
     MockMt310s2d *m_mt310s2d;

--- a/zenux-service-common/demolib/mockcom5003d.cpp
+++ b/zenux-service-common/demolib/mockcom5003d.cpp
@@ -3,7 +3,9 @@
 #include "mockserverparamgenerator.h"
 #include "mocki2ceepromiofactory.h"
 
-MockCom5003d::MockCom5003d(AbstractFactoryI2cCtrlPtr ctrlFactory, QString alternateConfigXml)
+MockCom5003d::MockCom5003d(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                           VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                           QString alternateConfigXml)
 {
     MockI2cEEpromIoFactory::enableMock();
 
@@ -14,5 +16,6 @@ MockCom5003d::MockCom5003d(AbstractFactoryI2cCtrlPtr ctrlFactory, QString altern
     m_server = std::make_unique<cCOM5003dServer>(
         std::move(settings),
         ctrlFactory,
-        std::make_shared<MockFactoryDeviceNodePcb>());
+        std::make_shared<MockFactoryDeviceNodePcb>(),
+        tcpWorkerFactory);
 }

--- a/zenux-service-common/demolib/mockcom5003d.h
+++ b/zenux-service-common/demolib/mockcom5003d.h
@@ -7,6 +7,7 @@ class MockCom5003d
 {
 public:
     MockCom5003d(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                 VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
                  QString alternateConfigXml = QString());
 private:
     std::unique_ptr<cCOM5003dServer> m_server;

--- a/zenux-service-common/demolib/mockmt310s2d.cpp
+++ b/zenux-service-common/demolib/mockmt310s2d.cpp
@@ -3,7 +3,9 @@
 #include "mockserverparamgenerator.h"
 #include "mocki2ceepromiofactory.h"
 
-MockMt310s2d::MockMt310s2d(AbstractFactoryI2cCtrlPtr ctrlFactory, QString alternateConfigXml)
+MockMt310s2d::MockMt310s2d(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                           VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                           QString alternateConfigXml)
 {
     MockI2cEEpromIoFactory::enableMock();
 
@@ -13,5 +15,6 @@ MockMt310s2d::MockMt310s2d(AbstractFactoryI2cCtrlPtr ctrlFactory, QString altern
     m_server = std::make_unique<cMT310S2dServer>(
         std::make_unique<SettingsContainer>(params),
         ctrlFactory,
-        std::make_shared<MockFactoryDeviceNodePcb>());
+        std::make_shared<MockFactoryDeviceNodePcb>(),
+        tcpWorkerFactory);
 }

--- a/zenux-service-common/demolib/mockmt310s2d.h
+++ b/zenux-service-common/demolib/mockmt310s2d.h
@@ -7,6 +7,7 @@ class MockMt310s2d
 {
 public:
     MockMt310s2d(AbstractFactoryI2cCtrlPtr ctrlFactory,
+                 VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
                  QString alternateConfigXml = QString());
 private:
     std::unique_ptr<cMT310S2dServer> m_server;

--- a/zenux-service-common/demolib/mocksec1000d.cpp
+++ b/zenux-service-common/demolib/mocksec1000d.cpp
@@ -2,7 +2,7 @@
 #include "mockfactorydevicenodesec.h"
 #include "mockserverparamgenerator.h"
 
-MockSec1000d::MockSec1000d(QString alternateConfigXml)
+MockSec1000d::MockSec1000d(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory, QString alternateConfigXml)
 {
     ServerParams params = MockServerParamGenerator::createParams("sec1000d");
     if(!alternateConfigXml.isEmpty())
@@ -10,5 +10,6 @@ MockSec1000d::MockSec1000d(QString alternateConfigXml)
 
     m_server = std::make_unique<cSEC1000dServer>(
         std::make_unique<SettingsContainer>(params),
-        std::make_shared<MockFactoryDeviceNodeSec>());
+        std::make_shared<MockFactoryDeviceNodeSec>(),
+        tcpWorkerFactory);
 }

--- a/zenux-service-common/demolib/mocksec1000d.h
+++ b/zenux-service-common/demolib/mocksec1000d.h
@@ -6,7 +6,8 @@
 class MockSec1000d
 {
 public:
-    MockSec1000d(QString alternateConfigXml = QString());
+    MockSec1000d(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                 QString alternateConfigXml = QString());
 private:
     std::unique_ptr<cSEC1000dServer> m_server;
 };

--- a/zenux-service-common/demolib/mockzdsp1d.cpp
+++ b/zenux-service-common/demolib/mockzdsp1d.cpp
@@ -1,11 +1,13 @@
 #include "mockzdsp1d.h"
 #include "mockserverparamgenerator.h"
 
-MockZdsp1d::MockZdsp1d(AbstractFactoryDeviceNodeDspPtr deviceNodeFactory, QString alternateConfigXml)
+MockZdsp1d::MockZdsp1d(AbstractFactoryDeviceNodeDspPtr deviceNodeFactory,
+                       VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                       QString alternateConfigXml)
 {
     ServerParams params = MockServerParamGenerator::createParams("zdsp1d");
     if(!alternateConfigXml.isEmpty())
         params.xmlFile = alternateConfigXml;
     SettingsContainerPtr settings = std::make_unique<SettingsContainer>(params);
-    m_server = std::make_unique<ZDspServer>(std::move(settings), deviceNodeFactory);
+    m_server = std::make_unique<ZDspServer>(std::move(settings), deviceNodeFactory, tcpWorkerFactory);
 }

--- a/zenux-service-common/demolib/mockzdsp1d.h
+++ b/zenux-service-common/demolib/mockzdsp1d.h
@@ -6,7 +6,9 @@
 class MockZdsp1d
 {
 public:
-    MockZdsp1d(AbstractFactoryDeviceNodeDspPtr deviceNodeFactory, QString alternateConfigXml = QString());
+    MockZdsp1d(AbstractFactoryDeviceNodeDspPtr deviceNodeFactory,
+               VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+               QString alternateConfigXml = QString());
 private:
     std::unique_ptr<ZDspServer> m_server;
 };

--- a/zenux-service-common/lib/scpi-interfaces/pcbserver.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/pcbserver.cpp
@@ -18,12 +18,6 @@ enum commands
     cmdUnregister
 };
 
-PCBServer::PCBServer(SettingsContainerPtr settings, cSCPI *scpiInterface) :
-    ScpiConnection(scpiInterface),
-    m_settings(std::move(settings))
-{
-}
-
 PCBServer::PCBServer(SettingsContainerPtr settings, cSCPI *scpiInterface,
                        VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
     ScpiConnection(scpiInterface),

--- a/zenux-service-common/lib/scpi-interfaces/pcbserver.h
+++ b/zenux-service-common/lib/scpi-interfaces/pcbserver.h
@@ -27,7 +27,6 @@ class PCBServer : public ScpiConnection
 {
     Q_OBJECT
 public:
-    explicit PCBServer(SettingsContainerPtr settings, cSCPI *scpiInterface);
     explicit PCBServer(SettingsContainerPtr settings, cSCPI *scpiInterface,
                         VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     void initSCPIConnection(QString leadingNodes) override;

--- a/zenux-service-common/testlib/testallservicescom5003.cpp
+++ b/zenux-service-common/testlib/testallservicescom5003.cpp
@@ -1,14 +1,26 @@
 #include "testallservicescom5003.h"
 #include <timemachineobject.h>
 #include "testfactorydevicenodedsp.h"
+#include <tcpworkerfactory.h>
 
 TestAllServicesCom5003::TestAllServicesCom5003(AbstractFactoryI2cCtrlPtr ctrlFactory)
 {
-    m_resman = new ResmanRunFacade;
+    init(VeinTcp::TcpWorkerFactory::create(), ctrlFactory);
+}
+
+TestAllServicesCom5003::TestAllServicesCom5003(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                               AbstractFactoryI2cCtrlPtr ctrlFactory)
+{
+    init(tcpWorkerFactory, ctrlFactory);
+}
+
+void TestAllServicesCom5003::init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory, AbstractFactoryI2cCtrlPtr ctrlFactory)
+{
+    m_resman = new ResmanRunFacade(tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
-    m_mockcom5003d = new MockCom5003d(ctrlFactory);
-    m_sec1000d = new MockSec1000d;
-    m_zdsp1d = new MockZdsp1d(std::make_shared<TestFactoryDeviceNodeDsp>());
+    m_mockcom5003d = new MockCom5003d(ctrlFactory, tcpWorkerFactory);
+    m_sec1000d = new MockSec1000d(tcpWorkerFactory);
+    m_zdsp1d = new MockZdsp1d(std::make_shared<TestFactoryDeviceNodeDsp>(), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 }
 

--- a/zenux-service-common/testlib/testallservicescom5003.h
+++ b/zenux-service-common/testlib/testallservicescom5003.h
@@ -12,8 +12,11 @@ class TestAllServicesCom5003 : public AbstractMockAllServices
 {
 public:
     TestAllServicesCom5003(AbstractFactoryI2cCtrlPtr ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(true));
+    TestAllServicesCom5003(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                           AbstractFactoryI2cCtrlPtr ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(true));
     virtual ~TestAllServicesCom5003();
 private:
+    void init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory, AbstractFactoryI2cCtrlPtr ctrlFactory);
     ResmanRunFacade *m_resman;
     MockCom5003d *m_mockcom5003d;
     MockSec1000d *m_sec1000d;

--- a/zenux-service-common/testlib/testallservicesmt310s2.cpp
+++ b/zenux-service-common/testlib/testallservicesmt310s2.cpp
@@ -1,14 +1,27 @@
 #include "testallservicesmt310s2.h"
 #include <timemachineobject.h>
 #include "testfactorydevicenodedsp.h"
+#include <tcpworkerfactory.h>
 
 TestAllServicesMt310s2::TestAllServicesMt310s2(AbstractFactoryI2cCtrlPtr ctrlFactory)
 {
-    m_resman = new ResmanRunFacade;
+    init(VeinTcp::TcpWorkerFactory::create(), ctrlFactory);
+}
+
+TestAllServicesMt310s2::TestAllServicesMt310s2(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                               AbstractFactoryI2cCtrlPtr ctrlFactory)
+{
+    init(tcpWorkerFactory, ctrlFactory);
+}
+
+void TestAllServicesMt310s2::init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                                  AbstractFactoryI2cCtrlPtr ctrlFactory)
+{
+    m_resman = new ResmanRunFacade(tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();;
-    m_mt310s2d = new MockMt310s2d(ctrlFactory);
-    m_sec1000d = new MockSec1000d;
-    m_zdsp1d = new MockZdsp1d(std::make_shared<TestFactoryDeviceNodeDsp>());
+    m_mt310s2d = new MockMt310s2d(ctrlFactory, tcpWorkerFactory);
+    m_sec1000d = new MockSec1000d(tcpWorkerFactory);
+    m_zdsp1d = new MockZdsp1d(std::make_shared<TestFactoryDeviceNodeDsp>(), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 }
 

--- a/zenux-service-common/testlib/testallservicesmt310s2.h
+++ b/zenux-service-common/testlib/testallservicesmt310s2.h
@@ -12,8 +12,11 @@ class TestAllServicesMt310s2 : public AbstractMockAllServices
 {
 public:
     TestAllServicesMt310s2(AbstractFactoryI2cCtrlPtr ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(true));
+    TestAllServicesMt310s2(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory,
+                           AbstractFactoryI2cCtrlPtr ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(true));
     virtual ~TestAllServicesMt310s2();
 private:
+    void init(VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory, AbstractFactoryI2cCtrlPtr ctrlFactory);
     ResmanRunFacade *m_resman;
     MockMt310s2d *m_mt310s2d;
     MockSec1000d *m_sec1000d;

--- a/zenux-service-common/testlib/testpcbserver.cpp
+++ b/zenux-service-common/testlib/testpcbserver.cpp
@@ -4,8 +4,9 @@
 #include <QFinalState>
 #include <QDir>
 
-TestPcbServer::TestPcbServer(QString serviceName) :
-    PCBServer(std::make_unique<SettingsContainer>(MockServerParamGenerator::createParams(serviceName)), ScpiSingletonFactory::getScpiObj())
+TestPcbServer::TestPcbServer(QString serviceName, VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
+    PCBServer(std::make_unique<SettingsContainer>(MockServerParamGenerator::createParams(serviceName)),
+                ScpiSingletonFactory::getScpiObj(), tcpWorkerFactory)
 {
     m_pInitializationMachine = new QStateMachine(this);
 

--- a/zenux-service-common/testlib/testpcbserver.h
+++ b/zenux-service-common/testlib/testpcbserver.h
@@ -14,7 +14,7 @@ class TestPcbServer : public PCBServer
 {
     Q_OBJECT
 public:
-    TestPcbServer(QString serviceName);
+    TestPcbServer(QString serviceName, VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     ~TestPcbServer();
     Zera::XMLConfig::cReader *getConfigReader();
     RMConnection* getRmConnection();

--- a/zenux-service-common/testlib/testpcbservernotifications.cpp
+++ b/zenux-service-common/testlib/testpcbservernotifications.cpp
@@ -1,8 +1,10 @@
 #include "testpcbservernotifications.h"
 #include "permissionfunctions.h"
 
-TestPcbServerNotifications::TestPcbServerNotifications(SettingsContainerPtr settings, cSCPI *scpiInterface, AbstractFactoryI2cCtrlPtr ctrlFactory) :
-    PCBServer(std::move(settings), scpiInterface)
+TestPcbServerNotifications::TestPcbServerNotifications(SettingsContainerPtr settings,
+                                                       cSCPI *scpiInterface, AbstractFactoryI2cCtrlPtr ctrlFactory,
+                                                       VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
+    PCBServer(std::move(settings), scpiInterface, tcpWorkerFactory)
 {
     scpiConnectionList.append(this);
     PermissionFunctions::setPermissionCtrlFactory(ctrlFactory);

--- a/zenux-service-common/testlib/testpcbservernotifications.h
+++ b/zenux-service-common/testlib/testpcbservernotifications.h
@@ -8,7 +8,9 @@ class TestPcbServerNotifications : public PCBServer
 {
     Q_OBJECT
 public:
-    TestPcbServerNotifications(SettingsContainerPtr settings, cSCPI *scpiInterface, AbstractFactoryI2cCtrlPtr ctrlFactory);
+    TestPcbServerNotifications(SettingsContainerPtr settings, cSCPI *scpiInterface,
+                               AbstractFactoryI2cCtrlPtr ctrlFactory,
+                               VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     ~TestPcbServerNotifications();
     void insertScpiConnection(ScpiConnection *scpiConnection);
     void initTestSCPIConnections();

--- a/zenux-service-common/tests/test_adj_procedure.cpp
+++ b/zenux-service-common/tests/test_adj_procedure.cpp
@@ -11,6 +11,7 @@
 #include "mt310s2systeminfomock.h"
 #include <timemachineobject.h>
 #include <testloghelpers.h>
+#include <tcpworkerfactory.h>
 #include <QFile>
 #include <QTest>
 
@@ -162,8 +163,9 @@ void test_adj_procedure::setupServers()
     AbstractFactoryI2cCtrlPtr ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(true);
     PermissionFunctions::setPermissionCtrlFactory(ctrlFactory);
 
-    m_resmanServer = std::make_unique<ResmanRunFacade>();
-    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory, true);
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resmanServer = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_testServer = std::make_unique<TestServerForSenseInterfaceMt310s2>(ctrlFactory, tcpWorkerFactory, true);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/zenux-service-common/tests/test_authorizationnotifier.cpp
+++ b/zenux-service-common/tests/test_authorizationnotifier.cpp
@@ -6,6 +6,7 @@
 #include <scpisingletonfactory.h>
 #include <timerfactoryqtfortest.h>
 #include <timemachinefortest.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 #include <QSignalSpy>
 
@@ -29,7 +30,7 @@ void test_authorizationnotifier::init()
     AbstractFactoryI2cCtrlPtr ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(false);
 
     m_PermissionCtrl = ctrlFactory->getPermissionCheckController();
-    m_pcbServerTest = std::make_unique<TestPcbServerNotifications>(std::make_unique<SettingsContainer>(params), scpiInterface, ctrlFactory);
+    m_pcbServerTest = std::make_unique<TestPcbServerNotifications>(std::make_unique<SettingsContainer>(params), scpiInterface, ctrlFactory, VeinTcp::TcpWorkerFactory::create());
     m_adjustmentStatusNull = new TestAdjustmentStatusInterfaceNull();
     m_pcbServerTest->insertScpiConnection(new cStatusInterface(m_pcbServerTest->getSCPIInterface(), m_adjustmentStatusNull, ctrlFactory));
     m_pcbServerTest->initTestSCPIConnections();

--- a/zenux-service-common/tests/test_fpga_settings_regression.cpp
+++ b/zenux-service-common/tests/test_fpga_settings_regression.cpp
@@ -9,6 +9,7 @@
 #include "mockserverparamgenerator.h"
 #include "testfactoryi2cctrl.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_fpga_settings_regression)
@@ -19,7 +20,8 @@ void test_fpga_settings_regression::com5003d()
     cCOM5003dServer server(
         std::make_unique<SettingsContainer>(params),
         std::make_shared<TestFactoryI2cCtrl>(true),
-        std::make_shared<MockFactoryDeviceNodePcb>());
+        std::make_shared<MockFactoryDeviceNodePcb>(),
+        VeinTcp::TcpWorkerFactory::create());
     TimeMachineObject::feedEventLoop();
 
     QCOMPARE(server.getCtrlDeviceNode(), "/dev/zFPGA1reg");
@@ -31,7 +33,8 @@ void test_fpga_settings_regression::mt310s2d()
     cMT310S2dServer server(
         std::make_unique<SettingsContainer>(params),
         std::make_shared<TestFactoryI2cCtrl>(true),
-        std::make_shared<MockFactoryDeviceNodePcb>());
+        std::make_shared<MockFactoryDeviceNodePcb>(),
+        VeinTcp::TcpWorkerFactory::create());
     TimeMachineObject::feedEventLoop();
 
     QCOMPARE(server.getCtrlDeviceNode(), "/dev/zFPGA1reg");
@@ -43,7 +46,8 @@ void test_fpga_settings_regression::sec1000d()
     ServerParams params = MockServerParamGenerator::createParams("sec1000d");
     cSEC1000dServer server(
         std::make_unique<SettingsContainer>(params),
-        std::make_shared<MockFactoryDeviceNodeSec>());
+        std::make_shared<MockFactoryDeviceNodeSec>(),
+        VeinTcp::TcpWorkerFactory::create());
     TimeMachineObject::feedEventLoop();
 
     QCOMPARE(server.getSecDeviceNode(), "/dev/zFPGA1ec");
@@ -54,7 +58,8 @@ void test_fpga_settings_regression::zdsp1d()
     ServerParams params = MockServerParamGenerator::createParams("zdsp1d");
     ZDspServer server(
         std::make_unique<SettingsContainer>(params),
-        std::make_shared<TestFactoryDeviceNodeDsp>());
+        std::make_shared<TestFactoryDeviceNodeDsp>(),
+        VeinTcp::TcpWorkerFactory::create());
     TimeMachineObject::feedEventLoop();
 
     QCOMPARE(server.getDspDeviceNode(), "/dev/zFPGA1dsp1");

--- a/zenux-service-common/tests/test_mockservice_com5003d_full.cpp
+++ b/zenux-service-common/tests/test_mockservice_com5003d_full.cpp
@@ -6,6 +6,7 @@
 #include "scpisingletransactionblocked.h"
 #include "zscpi_response_definitions.h"
 #include <mockeeprom24lc.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -18,8 +19,9 @@ void test_mockservice_com5003d_full::initTestCase()
 
 void test_mockservice_com5003d_full::init()
 {
-    m_resman = std::make_unique<ResmanRunFacade>();
-    m_server = std::make_unique<MockCom5003d>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resman = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_server = std::make_unique<MockCom5003d>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/zenux-service-common/tests/test_mockservice_mt310s2d_full.cpp
+++ b/zenux-service-common/tests/test_mockservice_mt310s2d_full.cpp
@@ -6,6 +6,7 @@
 #include "scpisingletransactionblocked.h"
 #include "zscpi_response_definitions.h"
 #include <mockeeprom24lc.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -18,8 +19,9 @@ void test_mockservice_mt310s2d_full::initTestCase()
 
 void test_mockservice_mt310s2d_full::init()
 {
-    m_resman = std::make_unique<ResmanRunFacade>();
-    m_mt310s2d = std::make_unique<MockMt310s2d>(std::make_shared<TestFactoryI2cCtrl>(true));
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resman = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
+    m_mt310s2d = std::make_unique<MockMt310s2d>(std::make_shared<TestFactoryI2cCtrl>(true), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 
     m_proxyClient = Zera::Proxy::getInstance()->getConnectionSmart("127.0.0.1", 6307);

--- a/zenux-service-common/tests/test_mockservice_sec1000d.cpp
+++ b/zenux-service-common/tests/test_mockservice_sec1000d.cpp
@@ -1,6 +1,7 @@
 #include "test_mockservice_sec1000d.h"
 #include "reply.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -13,9 +14,10 @@ void test_mockservice_sec1000d::initTestCase()
 
 void test_mockservice_sec1000d::init()
 {
-    m_resman = std::make_unique<ResmanRunFacade>();
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resman = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
-    m_sec1000d = std::make_unique<MockSec1000d>();
+    m_sec1000d = std::make_unique<MockSec1000d>(tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
     m_proxy = std::make_unique<ProxyForTest>();
 }

--- a/zenux-service-common/tests/test_mockservice_zdsp1d.cpp
+++ b/zenux-service-common/tests/test_mockservice_zdsp1d.cpp
@@ -4,6 +4,7 @@
 #include "reply.h"
 #include "testfactorydevicenodedsp.h"
 #include <timemachineobject.h>
+#include <tcpworkerfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -16,9 +17,10 @@ void test_mockservice_zdsp1d::initTestCase()
 
 void test_mockservice_zdsp1d::init()
 {
-    m_resman = std::make_unique<ResmanRunFacade>();
+    VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory = VeinTcp::TcpWorkerFactory::create();
+    m_resman = std::make_unique<ResmanRunFacade>(tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
-    m_zsdp1d = std::make_unique<MockZdsp1d>(std::make_shared<TestFactoryDeviceNodeDsp>());
+    m_zsdp1d = std::make_unique<MockZdsp1d>(std::make_shared<TestFactoryDeviceNodeDsp>(), tcpWorkerFactory);
     TimeMachineObject::feedEventLoop();
 }
 

--- a/zenux-service-common/tests/test_sense_settings.cpp
+++ b/zenux-service-common/tests/test_sense_settings.cpp
@@ -1,6 +1,7 @@
 #include "test_sense_settings.h"
 #include "testpcbserver.h"
 #include "sensesettings.h"
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_sense_settings);
@@ -8,14 +9,14 @@ QTEST_MAIN(test_sense_settings);
 class MockForSenseSettings  : public TestPcbServer
 {
 public:
-    MockForSenseSettings(QString deamonName);
+    MockForSenseSettings(QString deamonName, VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory);
     cSenseSettings* getSenseSettings() { return m_senseSettings.get(); }
 private:
     std::unique_ptr<cSenseSettings> m_senseSettings;
 };
 
-MockForSenseSettings::MockForSenseSettings(QString deamonName) :
-    TestPcbServer(deamonName)
+MockForSenseSettings::MockForSenseSettings(QString deamonName, VeinTcp::AbstractTcpWorkerFactoryPtr tcpWorkerFactory) :
+    TestPcbServer(deamonName, tcpWorkerFactory)
 {
     m_senseSettings = std::make_unique<cSenseSettings>(getConfigReader(), 8);
     setXmlSettings(XmlSettingsList{m_senseSettings.get()});
@@ -24,7 +25,7 @@ MockForSenseSettings::MockForSenseSettings(QString deamonName) :
 
 void test_sense_settings::findByAlias1Com5003()
 {
-    MockForSenseSettings mock("com5003d");
+    MockForSenseSettings mock("com5003d", VeinTcp::TcpWorkerFactory::create());
     cSenseSettings* senseSettings = mock.getSenseSettings();
     // we have this assumption on config all over the place
     QCOMPARE(senseSettings->findChannelSettingByAlias1("UL1")->m_nameMx, "m0");
@@ -37,7 +38,7 @@ void test_sense_settings::findByAlias1Com5003()
 
 void test_sense_settings::findByAlias1Mt310s2()
 {
-    MockForSenseSettings mock("mt310s2d");
+    MockForSenseSettings mock("mt310s2d", VeinTcp::TcpWorkerFactory::create());
     cSenseSettings* senseSettings = mock.getSenseSettings();
     // we have this assumption on config all over the place
     QCOMPARE(senseSettings->findChannelSettingByAlias1("UL1")->m_nameMx, "m0");
@@ -52,7 +53,7 @@ void test_sense_settings::findByAlias1Mt310s2()
 
 void test_sense_settings::findByInMxCom5003()
 {
-    MockForSenseSettings mock("com5003d");
+    MockForSenseSettings mock("com5003d", VeinTcp::TcpWorkerFactory::create());
     cSenseSettings* senseSettings = mock.getSenseSettings();
     // we have this assumption on config all over the place
     QCOMPARE(senseSettings->findChannelSettingByMxName("m0")->m_nameMx, "m0");

--- a/zenux-service-common/tests/test_serverunregisternotifier.cpp
+++ b/zenux-service-common/tests/test_serverunregisternotifier.cpp
@@ -3,6 +3,7 @@
 #include "testfactoryi2cctrl.h"
 #include "accumulatorinterface.h"
 #include "foutgroupresourceandinterface.h"
+#include <tcpworkerfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_serverunregisternotifier)
@@ -18,7 +19,10 @@ void test_serverunregisternotifier::init()
     
     m_adjustmentStatusNull = std::make_unique<TestAdjustmentStatusInterfaceNull>();
     m_ctrlFactory = std::make_shared<TestFactoryI2cCtrl>(true);
-    m_pcbServerTest = std::make_unique<TestPcbServerNotifications>(std::make_unique<SettingsContainer>(params), &m_scpiInterface, m_ctrlFactory);
+    m_pcbServerTest = std::make_unique<TestPcbServerNotifications>(std::make_unique<SettingsContainer>(params),
+                                                                   &m_scpiInterface,
+                                                                   m_ctrlFactory,
+                                                                   VeinTcp::TcpWorkerFactory::create());
 
     m_xmlConfigReader = std::make_unique<Zera::XMLConfig::cReader>();
     m_foutSettings = std::make_unique<FOutSettings>(m_xmlConfigReader.get());


### PR DESCRIPTION
* Did not find smaller steps
* For now we inject real tcp in tests - there is no tcp-worker injection on clients yet
* We tried hard not to affect depending projects as zera-classes