### PR TITLE
Many tests: Use mock network where we can without deep investigation

### DIFF
--- a/com5003d/tests/test_regression_sense_interface_com5003.cpp
+++ b/com5003d/tests/test_regression_sense_interface_com5003.cpp
@@ -5,7 +5,7 @@
 #include "proxy.h"
 #include "zscpi_response_definitions.h"
 #include <timemachineobject.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QRegularExpression>
 #include <QJsonValue>
 #include <QJsonDocument>
@@ -16,7 +16,7 @@ QTEST_MAIN(test_regression_sense_interface_com5003);
 
 void test_regression_sense_interface_com5003::init()
 {
-    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resmanServer = std::make_unique<ResmanRunFacade>(tcpNetworkFactory);
     m_testServer = std::make_unique<TestServerForSenseInterfaceCom5003>(
         std::make_shared<TestFactoryI2cCtrl>(true),

--- a/mt310s2d/tests/test_accumulatorinterface_mock.cpp
+++ b/mt310s2d/tests/test_accumulatorinterface_mock.cpp
@@ -5,7 +5,7 @@
 #include <timemachineobject.h>
 #include <timerfactoryqtfortest.h>
 #include <timemachinefortest.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -99,7 +99,7 @@ void test_accumulatorinterface_mock::readAccuStateOfChargeAccuEnabled()
 
 void test_accumulatorinterface_mock::setupServers(QString configFileXml)
 {
-    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resman = std::make_unique<ResmanRunFacade>(tcpNetworkFactory);
     m_mt310s2d = std::make_unique<MockMt310s2d>(std::make_shared<TestFactoryI2cCtrl>(true), tcpNetworkFactory, configFileXml);
     TimeMachineObject::feedEventLoop();

--- a/sec1000d/tests/test_regression_scpi_sec1000.cpp
+++ b/sec1000d/tests/test_regression_scpi_sec1000.cpp
@@ -4,14 +4,14 @@
 #include <xmldocumentcompare.h>
 #include <testloghelpers.h>
 #include <timemachineobject.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_regression_scpi_sec1000);
 
 void test_regression_scpi_sec1000::init()
 {
-    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resman = std::make_unique<ResmanRunFacade>(tcpNetworkFactory);
     m_server = std::make_unique<MockSec1000d>(tcpNetworkFactory);
     TimeMachineObject::feedEventLoop();

--- a/sec1000d/tests/test_sec_resource.cpp
+++ b/sec1000d/tests/test_sec_resource.cpp
@@ -1,7 +1,7 @@
 #include "test_sec_resource.h"
 #include "mockfactorydevicenodesec.h"
 #include "zscpi_response_definitions.h"
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <timemachineobject.h>
 #include <QTest>
 #include <QList>
@@ -101,7 +101,7 @@ void test_sec_resource::setSecChannelsForMultipleClientsFreeOneClient()
 
 void test_sec_resource::setSecChannelsForMultipleClientsOnePeerFreePeer()
 {
-    VeinTcp::TcpPeer peer(VeinTcp::TcpNetworkFactory::create());
+    VeinTcp::TcpPeer peer(VeinTcp::MockTcpNetworkFactory::create());
     sendScpiCommand(&peer, QByteArray(1, '1'), setFourResourcesCommand);
     sendScpiCommand(&peer, QByteArray(1, '2'), setFourResourcesCommand);
     QVERIFY(m_secResource->freeChannelsForThisPeer(&peer));
@@ -112,11 +112,11 @@ void test_sec_resource::setSecChannelsForMultipleClientsOnePeerFreePeer()
 
 void test_sec_resource::setSecChannelsForMultipleClientsMultiplePeersFreeOnePeer()
 {
-    VeinTcp::TcpPeer peer(VeinTcp::TcpNetworkFactory::create());
+    VeinTcp::TcpPeer peer(VeinTcp::MockTcpNetworkFactory::create());
     sendScpiCommand(&peer, QByteArray(1, '1'), setTwoResourcesCommand);
     sendScpiCommand(&peer, QByteArray(1, '2'), setTwoResourcesCommand);
 
-    VeinTcp::TcpPeer peer1(VeinTcp::TcpNetworkFactory::create());
+    VeinTcp::TcpPeer peer1(VeinTcp::MockTcpNetworkFactory::create());
     QString channelsSet = sendScpiCommand(&peer1, QByteArray(1, '3'), setTwoResourcesCommand);
     channelsSet.append(sendScpiCommand(&peer1, QByteArray(1, '4'), setTwoResourcesCommand));
 
@@ -134,10 +134,10 @@ void test_sec_resource::setSecChannelsForMultipleClientsMultiplePeersFreeOnePeer
 
 void test_sec_resource::freeChannelsFromInvalidPeer()
 {
-    VeinTcp::TcpPeer peer(VeinTcp::TcpNetworkFactory::create());
+    VeinTcp::TcpPeer peer(VeinTcp::MockTcpNetworkFactory::create());
     sendScpiCommand(&peer, QByteArray(1, '1'), setTwoResourcesCommand);
     sendScpiCommand(&peer, QByteArray(1, '2'), setTwoResourcesCommand);
 
-    VeinTcp::TcpPeer peer1(VeinTcp::TcpNetworkFactory::create());
+    VeinTcp::TcpPeer peer1(VeinTcp::MockTcpNetworkFactory::create());
     QVERIFY(m_secResource->freeChannelsForThisPeer(&peer1)); //because no channels were set
 }

--- a/zdsp1d/tests/test_regression_dsp_var.cpp
+++ b/zdsp1d/tests/test_regression_dsp_var.cpp
@@ -7,7 +7,7 @@
 #include "testfactorydevicenodedsp.h"
 #include "testsingletondevicenodedsp.h"
 #include <timemachineobject.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QDataStream>
 #include <QSignalSpy>
 #include <QTest>
@@ -18,7 +18,7 @@ static constexpr quint16 dspServerPort = 6310;
 
 void test_regression_dsp_var::init()
 {
-    m_tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    m_tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resmanServer = std::make_unique<ResmanRunFacade>(m_tcpNetworkFactory);
     m_deviceNodeFactory = std::make_shared<TestFactoryDeviceNodeDsp>();
     m_dspService = std::make_unique<TestZdsp1dForVarAccess>(m_deviceNodeFactory, m_tcpNetworkFactory);

--- a/zdsp1d/tests/test_regression_scpi_zdsp1d.cpp
+++ b/zdsp1d/tests/test_regression_scpi_zdsp1d.cpp
@@ -5,14 +5,14 @@
 #include <xmldocumentcompare.h>
 #include <testloghelpers.h>
 #include <timemachineobject.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QTest>
 
 QTEST_MAIN(test_regression_scpi_zdsp1d);
 
 void test_regression_scpi_zdsp1d::init()
 {
-    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resman = std::make_unique<ResmanRunFacade>(tcpNetworkFactory);
     m_server = std::make_unique<MockZdsp1d>(std::make_shared<TestFactoryDeviceNodeDsp>(), tcpNetworkFactory);
     TimeMachineObject::feedEventLoop();

--- a/zenux-service-common/tests/test_mockservice_com5003d_full.cpp
+++ b/zenux-service-common/tests/test_mockservice_com5003d_full.cpp
@@ -6,7 +6,7 @@
 #include "scpisingletransactionblocked.h"
 #include "zscpi_response_definitions.h"
 #include <mockeeprom24lc.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -19,7 +19,7 @@ void test_mockservice_com5003d_full::initTestCase()
 
 void test_mockservice_com5003d_full::init()
 {
-    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resman = std::make_unique<ResmanRunFacade>(tcpNetworkFactory);
     m_server = std::make_unique<MockCom5003d>(std::make_shared<TestFactoryI2cCtrl>(true), tcpNetworkFactory);
     TimeMachineObject::feedEventLoop();

--- a/zenux-service-common/tests/test_mockservice_mt310s2d_full.cpp
+++ b/zenux-service-common/tests/test_mockservice_mt310s2d_full.cpp
@@ -6,7 +6,7 @@
 #include "scpisingletransactionblocked.h"
 #include "zscpi_response_definitions.h"
 #include <mockeeprom24lc.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -19,7 +19,7 @@ void test_mockservice_mt310s2d_full::initTestCase()
 
 void test_mockservice_mt310s2d_full::init()
 {
-    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    VeinTcp::AbstractTcpNetworkFactoryPtr tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resman = std::make_unique<ResmanRunFacade>(tcpNetworkFactory);
     m_mt310s2d = std::make_unique<MockMt310s2d>(std::make_shared<TestFactoryI2cCtrl>(true), tcpNetworkFactory);
     TimeMachineObject::feedEventLoop();

--- a/zenux-service-common/tests/test_mockservice_zdsp1d.cpp
+++ b/zenux-service-common/tests/test_mockservice_zdsp1d.cpp
@@ -4,7 +4,7 @@
 #include "reply.h"
 #include "testfactorydevicenodedsp.h"
 #include <timemachineobject.h>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -17,7 +17,7 @@ void test_mockservice_zdsp1d::initTestCase()
 
 void test_mockservice_zdsp1d::init()
 {
-    m_tcpNetworkFactory = VeinTcp::TcpNetworkFactory::create();
+    m_tcpNetworkFactory = VeinTcp::MockTcpNetworkFactory::create();
     m_resman = std::make_unique<ResmanRunFacade>(m_tcpNetworkFactory);
     TimeMachineObject::feedEventLoop();
     m_zsdp1d = std::make_unique<MockZdsp1d>(std::make_shared<TestFactoryDeviceNodeDsp>(), m_tcpNetworkFactory);

--- a/zenux-service-common/tests/test_notificationsubscriber.cpp
+++ b/zenux-service-common/tests/test_notificationsubscriber.cpp
@@ -1,12 +1,12 @@
 #include "test_notificationsubscriber.h"
 #include <QTest>
-#include <tcpnetworkfactory.h>
+#include <mocktcpnetworkfactory.h>
 
 QTEST_MAIN(test_notificationsubscriber);
 
 void test_notificationsubscriber::init()
 {
-    m_netPeer = new VeinTcp::TcpPeer(VeinTcp::TcpNetworkFactory::create());
+    m_netPeer = new VeinTcp::TcpPeer(VeinTcp::MockTcpNetworkFactory::create());
     m_notificationHandler = new ScpiNotificationSubscriberHandler();
 }
 


### PR DESCRIPTION
Coming back to my many core host invites me with:

| Server could not listen on port: 6312 error: "The bound address is already in use"

due to tests of zenux-services & zera-classes running at the same time in OE builds.

As mentioned there are still some using real network so we just reduce error probability.