### PR TITLE
Fix cProtonetCommand memory leaks by using shared pointers / rename -…

### DIFF
--- a/com5003d/lib/scpi-interfaces/com5003systeminterface.cpp
+++ b/com5003d/lib/scpi-interfaces/com5003systeminterface.cpp
@@ -38,7 +38,7 @@ void Com5003SystemInterface::initSCPIConnection(QString leadingNodes)
 }
 
 
-void Com5003SystemInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void Com5003SystemInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/com5003d/lib/scpi-interfaces/com5003systeminterface.h
+++ b/com5003d/lib/scpi-interfaces/com5003systeminterface.h
@@ -39,7 +39,7 @@ public:
     virtual void initSCPIConnection(QString leadingNodes) override;
 
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 
 private:
     QString scpiReadServerVersion(QString& sInput);

--- a/com5003d/tests/test_regression_sense_range_com5003.cpp
+++ b/com5003d/tests/test_regression_sense_range_com5003.cpp
@@ -37,7 +37,7 @@ void test_regression_sense_range_com5003::checkAlias()
     QString scpiAliasQuery = "SENSE:m0:240V:ALIAS?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiAliasQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAliasQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAliasQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "240V");
@@ -45,7 +45,7 @@ void test_regression_sense_range_com5003::checkAlias()
     QString scpiAliasCmd = "SENSE:m0:240V:ALIAS FOO;";
     scpiObject = m_scpiInterface->getSCPIObject(scpiAliasCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAliasCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAliasCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -57,7 +57,7 @@ void test_regression_sense_range_com5003::checkAvail()
     QString scpiAvailQuery = "SENSE:m0:240V:AVAIL?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiAvailQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAvailQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAvailQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "1");
@@ -65,7 +65,7 @@ void test_regression_sense_range_com5003::checkAvail()
     QString scpiAvailCmd = "SENSE:m0:240V:AVAIL 0;";
     scpiObject = m_scpiInterface->getSCPIObject(scpiAvailCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAvailCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAvailCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -78,7 +78,7 @@ void test_regression_sense_range_com5003::checkUrValue()
     QString scpiUrValueQuery = "SENSE:m0:240V:URVALUE?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiUrValueQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiUrValueQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiUrValueQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "11111.1");
@@ -86,7 +86,7 @@ void test_regression_sense_range_com5003::checkUrValue()
     QString scpiUrValueCmd = "SENSE:m0:240V:URVALUE 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiUrValueCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiUrValueCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiUrValueCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -97,7 +97,7 @@ void test_regression_sense_range_com5003::checkRejection()
     QString scpiRejectionQuery = "SENSE:m0:240V:REJECTION?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "22222.2");
@@ -105,7 +105,7 @@ void test_regression_sense_range_com5003::checkRejection()
     QString scpiRejectionCmd = "SENSE:m0:240V:REJECTION 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -116,7 +116,7 @@ void test_regression_sense_range_com5003::checkOvRejection()
     QString scpiOvRejectionQuery = "SENSE:m0:240V:OVREJECTION?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiOvRejectionQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiOvRejectionQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiOvRejectionQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "33333.3");
@@ -124,7 +124,7 @@ void test_regression_sense_range_com5003::checkOvRejection()
     QString scpiOvRejectionCmd = "SENSE:m0:240V:OVREJECTION 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiOvRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiOvRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiOvRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -135,7 +135,7 @@ void test_regression_sense_range_com5003::checkAdcRejection()
     QString scpiAdcRejectionQuery = "SENSE:m0:240V:ADCREJECTION?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiAdcRejectionQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAdcRejectionQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAdcRejectionQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "8388607");
@@ -143,7 +143,7 @@ void test_regression_sense_range_com5003::checkAdcRejection()
     QString scpiAdcRejectionCmd = "SENSE:m0:240V:ADCREJECTION 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiAdcRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAdcRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAdcRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -159,7 +159,7 @@ void test_regression_sense_range_com5003::checkTypeOrMask()
     QString scpiRejectionType = "SENSE:m0:240V:TYPE?";
     cSCPIObject* scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionType);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand* protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionType);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionType);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), QString("%1").arg(modeAC));
@@ -167,7 +167,7 @@ void test_regression_sense_range_com5003::checkTypeOrMask()
     QString scpiRejectionCmd = "SENSE:m0:240V:TYPE 1";
     scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput),ZSCPI::scpiAnswer[ZSCPI::nak]);

--- a/mt310s2d/lib/scpi-interfaces/mt310s2systeminterface.cpp
+++ b/mt310s2d/lib/scpi-interfaces/mt310s2systeminterface.cpp
@@ -76,7 +76,7 @@ void Mt310s2SystemInterface::onAccuStatusChanged(uint8_t status)
     }
 }
 
-void Mt310s2SystemInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void Mt310s2SystemInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/mt310s2d/lib/scpi-interfaces/mt310s2systeminterface.h
+++ b/mt310s2d/lib/scpi-interfaces/mt310s2systeminterface.h
@@ -44,7 +44,7 @@ public:
 public slots:
     void onAccuStatusChanged(uint8_t status);
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadServerVersion(QString& sInput);
     QString scpiReadAllCTRLVersions(QString& sInput);

--- a/mt310s2d/tests/test_regression_sense_range_mt310s2.cpp
+++ b/mt310s2d/tests/test_regression_sense_range_mt310s2.cpp
@@ -37,7 +37,7 @@ void test_regression_sense_range_mt310s2::checkAlias()
     QString scpiAliasQuery = "SENSE:m0:250V:ALIAS?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiAliasQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAliasQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAliasQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "250V");
@@ -45,7 +45,7 @@ void test_regression_sense_range_mt310s2::checkAlias()
     QString scpiAliasCmd = "SENSE:m0:250V:ALIAS FOO;";
     scpiObject = m_scpiInterface->getSCPIObject(scpiAliasCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAliasCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAliasCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -57,7 +57,7 @@ void test_regression_sense_range_mt310s2::checkAvail()
     QString scpiAvailQuery = "SENSE:m0:250V:AVAIL?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiAvailQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAvailQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAvailQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "1");
@@ -65,7 +65,7 @@ void test_regression_sense_range_mt310s2::checkAvail()
     QString scpiAvailCmd = "SENSE:m0:250V:AVAIL 0;";
     scpiObject = m_scpiInterface->getSCPIObject(scpiAvailCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAvailCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAvailCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -80,7 +80,7 @@ void test_regression_sense_range_mt310s2::checkUrValue()
     QString scpiUrValueQuery = "SENSE:m0:250V:URVALUE?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiUrValueQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiUrValueQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiUrValueQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "11111.1");
@@ -88,7 +88,7 @@ void test_regression_sense_range_mt310s2::checkUrValue()
     QString scpiUrValueCmd = "SENSE:m0:250V:URVALUE 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiUrValueCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiUrValueCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiUrValueCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -99,7 +99,7 @@ void test_regression_sense_range_mt310s2::checkRejection()
     QString scpiRejectionQuery = "SENSE:m0:250V:REJECTION?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "22222.222");
@@ -107,7 +107,7 @@ void test_regression_sense_range_mt310s2::checkRejection()
     QString scpiRejectionCmd = "SENSE:m0:250V:REJECTION 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -118,7 +118,7 @@ void test_regression_sense_range_mt310s2::checkOvRejection()
     QString scpiOvRejectionQuery = "SENSE:m0:250V:OVREJECTION?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiOvRejectionQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiOvRejectionQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiOvRejectionQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "33333.333");
@@ -126,7 +126,7 @@ void test_regression_sense_range_mt310s2::checkOvRejection()
     QString scpiOvRejectionCmd = "SENSE:m0:250V:OVREJECTION 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiOvRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiOvRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiOvRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -137,7 +137,7 @@ void test_regression_sense_range_mt310s2::checkAdcRejection()
     QString scpiAdcRejectionQuery = "SENSE:m0:250V:ADCREJECTION?";
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(scpiAdcRejectionQuery);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand *protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAdcRejectionQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAdcRejectionQuery);
     cSCPIDelegate *scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), "8388607");
@@ -145,7 +145,7 @@ void test_regression_sense_range_mt310s2::checkAdcRejection()
     QString scpiAdcRejectionCmd = "SENSE:m0:250V:ADCREJECTION 42";
     scpiObject = m_scpiInterface->getSCPIObject(scpiAdcRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiAdcRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiAdcRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::nak]);
@@ -164,7 +164,7 @@ void test_regression_sense_range_mt310s2::checkTypeOrMask()
     QString scpiRejectionType = "SENSE:m0:250V:TYPE?";
     cSCPIObject* scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionType);
     QVERIFY(scpiObject != nullptr);
-    cProtonetCommand* protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionType);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionType);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput), QString("%1").arg(expectedMask));
@@ -172,7 +172,7 @@ void test_regression_sense_range_mt310s2::checkTypeOrMask()
     QString scpiRejectionCmd = "SENSE:m0:250V:TYPE 1";
     scpiObject = m_scpiInterface->getSCPIObject(scpiRejectionCmd);
     QVERIFY(scpiObject != nullptr);
-    protoCmd = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiRejectionCmd);
+    protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiRejectionCmd);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);
     QCOMPARE((protoCmd->m_sOutput),ZSCPI::scpiAnswer[ZSCPI::nak]);

--- a/sec1000d/lib/resources/secgroupresourceandinterface.cpp
+++ b/sec1000d/lib/resources/secgroupresourceandinterface.cpp
@@ -60,7 +60,7 @@ void SecGroupResourceAndInterface::initSCPIConnection(QString leadingNodes)
     connectChannelSignalsAndInitScpi();
 }
 
-void SecGroupResourceAndInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void SecGroupResourceAndInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {
@@ -130,7 +130,7 @@ QString SecGroupResourceAndInterface::scpiReadECalculatorChannelCatalog(const QS
     return ZSCPI::scpiAnswer[ZSCPI::nak];
 }
 
-void SecGroupResourceAndInterface::scpiSetChannels(cProtonetCommand *protoCmd)
+void SecGroupResourceAndInterface::scpiSetChannels(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
 
@@ -177,7 +177,7 @@ void SecGroupResourceAndInterface::scpiSetChannels(cProtonetCommand *protoCmd)
 }
 
 
-void SecGroupResourceAndInterface::scpiFreeChannels(cProtonetCommand *protoCmd)
+void SecGroupResourceAndInterface::scpiFreeChannels(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     protoCmd->m_sOutput = ZSCPI::scpiAnswer[ZSCPI::nak]; // preset

--- a/sec1000d/lib/resources/secgroupresourceandinterface.h
+++ b/sec1000d/lib/resources/secgroupresourceandinterface.h
@@ -32,7 +32,7 @@ public:
     QList<SecChannel*> getECalcChannelList();
     bool freeChannelsForThisPeer(VeinTcp::TcpPeer *peer);
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 
 private:
     SecCalculatorSettings* m_pecalcsettings;
@@ -44,8 +44,8 @@ private:
 
     QString scpiReadVersion(const QString& scpi);
     QString scpiReadECalculatorChannelCatalog(const QString& scpi);
-    void scpiSetChannels(cProtonetCommand *protoCmd);
-    void scpiFreeChannels(cProtonetCommand *protoCmd);
+    void scpiSetChannels(ProtonetCommandPtr protoCmd);
+    void scpiFreeChannels(ProtonetCommandPtr protoCmd);
     bool freeChannelsFromAClient(QByteArray clientID);
     void connectChannelSignalsAndInitScpi();
 };

--- a/sec1000d/lib/scpi-interfaces/sec1000statusinterface.cpp
+++ b/sec1000d/lib/scpi-interfaces/sec1000statusinterface.cpp
@@ -13,7 +13,7 @@ void Sec1000StatusInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1STATUS").arg(leadingNodes),"DEVICE",SCPI::isQuery, m_scpiInterface, StatusSystem::cmdDevice);
 }
 
-void Sec1000StatusInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void Sec1000StatusInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
 

--- a/sec1000d/lib/scpi-interfaces/sec1000statusinterface.h
+++ b/sec1000d/lib/scpi-interfaces/sec1000statusinterface.h
@@ -23,7 +23,7 @@ public:
     Sec1000StatusInterface(std::shared_ptr<cSCPI> scpiInterface);
     virtual void initSCPIConnection(QString leadingNodes) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     quint16 getDeviceStatus();
 };

--- a/sec1000d/lib/scpi-interfaces/sec1000systeminterface.h
+++ b/sec1000d/lib/scpi-interfaces/sec1000systeminterface.h
@@ -28,7 +28,7 @@ public:
     cSystemInterface(std::shared_ptr<cSCPI> scpiInterface, cSEC1000dServer* server, Sec1000SystemInfo* sInfo);
     virtual void initSCPIConnection(QString leadingNodes) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     cSEC1000dServer* m_pMyServer;
     Sec1000SystemInfo* m_pSystemInfo;

--- a/sec1000d/lib/scpi-interfaces/sec100systeminterface.cpp
+++ b/sec1000d/lib/scpi-interfaces/sec100systeminterface.cpp
@@ -25,7 +25,7 @@ void cSystemInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1SYSTEM:INTERFACE").arg(leadingNodes), "READ", SCPI::isQuery, m_scpiInterface, SystemSystem::cmdInterfaceRead);
 }
 
-void cSystemInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void cSystemInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/sec1000d/lib/scpi-interfaces/secchannel.cpp
+++ b/sec1000d/lib/scpi-interfaces/secchannel.cpp
@@ -83,7 +83,7 @@ void SecChannel::initSCPIConnection(QString leadingNodes)
 }
 
 
-void SecChannel::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void SecChannel::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {
@@ -150,7 +150,7 @@ void SecChannel::setIntReg(quint8 reg)
 }
 
 
-void SecChannel::m_ReadWriteRegister(cProtonetCommand *protoCmd)
+void SecChannel::m_ReadWriteRegister(ProtonetCommandPtr protoCmd)
 {
     bool ok;
     quint32 reg;
@@ -210,7 +210,7 @@ void SecChannel::m_ReadWriteRegister(cProtonetCommand *protoCmd)
         protoCmd->m_sOutput = ZSCPI::scpiAnswer[ZSCPI::nak];
 }
 
-void SecChannel::m_setSync(cProtonetCommand *protoCmd)
+void SecChannel::m_setSync(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isCommand(1)) {
@@ -239,7 +239,7 @@ void SecChannel::m_setSync(cProtonetCommand *protoCmd)
         protoCmd->m_sOutput = ZSCPI::scpiAnswer[ZSCPI::nak];
 }
 
-void SecChannel::m_setMux(cProtonetCommand *protoCmd)
+void SecChannel::m_setMux(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isCommand(1)) {
@@ -263,7 +263,7 @@ void SecChannel::m_setMux(cProtonetCommand *protoCmd)
         protoCmd->m_sOutput = ZSCPI::scpiAnswer[ZSCPI::nak];
 }
 
-void SecChannel::m_setCmdId(cProtonetCommand *protoCmd)
+void SecChannel::m_setCmdId(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isCommand(1)) {
@@ -289,7 +289,7 @@ void SecChannel::m_setCmdId(cProtonetCommand *protoCmd)
         protoCmd->m_sOutput = ZSCPI::scpiAnswer[ZSCPI::nak];
 }
 
-void SecChannel::m_start(cProtonetCommand *protoCmd)
+void SecChannel::m_start(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isCommand(0)) {
@@ -311,7 +311,7 @@ void SecChannel::m_start(cProtonetCommand *protoCmd)
 }
 
 
-void SecChannel::m_stop(cProtonetCommand *protoCmd)
+void SecChannel::m_stop(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isCommand(0)) {
@@ -326,7 +326,7 @@ void SecChannel::m_stop(cProtonetCommand *protoCmd)
         protoCmd->m_sOutput = ZSCPI::scpiAnswer[ZSCPI::nak];
 }
 
-void SecChannel::m_resetInt(cProtonetCommand *protoCmd)
+void SecChannel::m_resetInt(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isCommand(1)) {

--- a/sec1000d/lib/scpi-interfaces/secchannel.h
+++ b/sec1000d/lib/scpi-interfaces/secchannel.h
@@ -35,7 +35,7 @@ public:
     void resetInterrupt(quint8 interrupt);
 
 protected:
-    virtual void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    virtual void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 
 private:
     AbstractFactoryDeviceNodeSecPtr m_deviceNodeFactory;
@@ -49,13 +49,13 @@ private:
     QString m_sName; // the channels name ec0...
     bool m_bSet; // we mark if the channel is occupied
     QByteArray m_ClientId; // we remark the clientid for arbitration purpose
-    void m_ReadWriteRegister(cProtonetCommand* protoCmd);
-    void m_setSync(cProtonetCommand* protoCmd);
-    void m_setMux(cProtonetCommand* protoCmd);
-    void m_setCmdId(cProtonetCommand* protoCmd);
-    void m_start(cProtonetCommand* protoCmd);
-    void m_stop(cProtonetCommand* protoCmd);
-    void m_resetInt(cProtonetCommand* protoCmd);
+    void m_ReadWriteRegister(ProtonetCommandPtr protoCmd);
+    void m_setSync(ProtonetCommandPtr protoCmd);
+    void m_setMux(ProtonetCommandPtr protoCmd);
+    void m_setCmdId(ProtonetCommandPtr protoCmd);
+    void m_start(ProtonetCommandPtr protoCmd);
+    void m_stop(ProtonetCommandPtr protoCmd);
+    void m_resetInt(ProtonetCommandPtr protoCmd);
 
     NotificationValue notifierECalcChannelIntReg;
     std::function<void(int)> m_funcSigHandler;

--- a/sec1000d/tests/test_sec_resource.cpp
+++ b/sec1000d/tests/test_sec_resource.cpp
@@ -43,11 +43,11 @@ void test_sec_resource::cleanup()
 
 QString test_sec_resource::sendScpiCommand(VeinTcp::TcpPeer *peer, QByteArray clientID, QString cmd)
 {
-    cProtonetCommand protoCmd(peer, false, false, clientID, 0, cmd);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(peer, false, false, clientID, 0, cmd);
     cSCPIObject *scpiObject = m_scpiInterface->getSCPIObject(cmd);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
-    scpiDelegate->executeSCPI(&protoCmd);
-    return protoCmd.m_sOutput;
+    scpiDelegate->executeSCPI(protoCmd);
+    return protoCmd->m_sOutput;
 }
 
 void test_sec_resource::setSecChannelsForAClient()

--- a/zdsp1d/lib/zdspserver.h
+++ b/zdsp1d/lib/zdspserver.h
@@ -44,7 +44,7 @@ signals:
     void abortInit();
 
 private slots:
-    void sendProtoAnswer(cProtonetCommand *protoCmd);
+    void sendProtoAnswer(ProtonetCommandPtr protoCmd);
     void onProtobufClientConnected(VeinTcp::TcpPeer* newClient);
     void onProtobufDataReceived(VeinTcp::TcpPeer *peer, QByteArray message);
     void onProtobufDisconnect(VeinTcp::TcpPeer *peer);
@@ -66,7 +66,7 @@ private slots:
 private:
     void init();
     void initSCPIConnection(QString leadingNodes) override;
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 
     friend class TestZdsp1dForVarAccess;
 

--- a/zenux-service-common/lib/adjustment/range/adjrangescpi.cpp
+++ b/zenux-service-common/lib/adjustment/range/adjrangescpi.cpp
@@ -107,7 +107,7 @@ AdjDataItemScpi *AdjRangeScpi::getAdjInterface(QString name)
     return nullptr;
 }
 
-void AdjRangeScpi::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void AdjRangeScpi::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/adjustment/range/adjrangescpi.h
+++ b/zenux-service-common/lib/adjustment/range/adjrangescpi.h
@@ -61,7 +61,7 @@ public:
     void computeJustData();
 
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     virtual double getGainCorrectionTotal(double par);
     virtual double getPhaseCorrectionTotal(double par);
     virtual double getOffsetCorrectionTotal(double par);

--- a/zenux-service-common/lib/adjustment/rangeitem/adjdataitemscpi.cpp
+++ b/zenux-service-common/lib/adjustment/rangeitem/adjdataitemscpi.cpp
@@ -46,7 +46,7 @@ AdjDataItem *AdjDataItemScpi::getAdjItem()
     return m_adjItem;
 }
 
-void AdjDataItemScpi::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void AdjDataItemScpi::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/adjustment/rangeitem/adjdataitemscpi.h
+++ b/zenux-service-common/lib/adjustment/rangeitem/adjdataitemscpi.h
@@ -31,7 +31,7 @@ public:
     void nodesFromString(const QString& s );
 
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     std::function<bool(bool &)> m_checkPermission;
 private:
     QString scpiReadWriteStatus(QString& sInput);

--- a/zenux-service-common/lib/resources/fingroupresourceandinterface.cpp
+++ b/zenux-service-common/lib/resources/fingroupresourceandinterface.cpp
@@ -51,7 +51,7 @@ void FInGroupResourceAndInterface::registerResource(RMConnection *rmConnection, 
         register1Resource(rmConnection, NotZeroNumGen::getMsgNr(), QString("FRQINPUT;%1;1;%2;%3;").arg(channel->getName(), channel->getDescription()).arg(port));
 }
 
-void FInGroupResourceAndInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void FInGroupResourceAndInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/resources/fingroupresourceandinterface.h
+++ b/zenux-service-common/lib/resources/fingroupresourceandinterface.h
@@ -18,7 +18,7 @@ public:
     virtual void initSCPIConnection(QString leadingNodes) override;
     virtual void registerResource(RMConnection *rmConnection, quint16 port) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString readVersion(QString& sInput);
     QString readChannelCatalog(QString& sInput);

--- a/zenux-service-common/lib/resources/foutgroupresourceandinterface.cpp
+++ b/zenux-service-common/lib/resources/foutgroupresourceandinterface.cpp
@@ -52,7 +52,7 @@ void FOutGroupResourceAndInterface::registerResource(RMConnection *rmConnection,
                           QString("SOURCE;%1;1;%2;%3;").arg(channel->getName(), channel->getDescription()).arg(port));
 }
 
-void FOutGroupResourceAndInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void FOutGroupResourceAndInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/resources/foutgroupresourceandinterface.h
+++ b/zenux-service-common/lib/resources/foutgroupresourceandinterface.h
@@ -18,7 +18,7 @@ public:
     virtual void initSCPIConnection(QString leadingNodes) override;
     virtual void registerResource(RMConnection *rmConnection, quint16 port) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString readVersion(QString &sInput);
     QString readSourceChannelCatalog(QString &sInput);

--- a/zenux-service-common/lib/resources/hkingroupresourceandinterface.cpp
+++ b/zenux-service-common/lib/resources/hkingroupresourceandinterface.cpp
@@ -43,7 +43,7 @@ void HkInGroupResourceAndInterface::registerResource(RMConnection *rmConnection,
         register1Resource(rmConnection, NotZeroNumGen::getMsgNr(), QString("HKEY;%1;1;%2;%3;").arg(channel->getName(), channel->getDescription()).arg(port));
 }
 
-void HkInGroupResourceAndInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void HkInGroupResourceAndInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/resources/hkingroupresourceandinterface.h
+++ b/zenux-service-common/lib/resources/hkingroupresourceandinterface.h
@@ -18,7 +18,7 @@ public:
     void initSCPIConnection(QString leadingNodes) override;
     void registerResource(RMConnection *rmConnection, quint16 port) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString readVersion(QString& sInput);
     QString readChannelCatalog(QString& sInput);

--- a/zenux-service-common/lib/resources/samplinginterface.cpp
+++ b/zenux-service-common/lib/resources/samplinginterface.cpp
@@ -38,7 +38,7 @@ void cSamplingInterface::registerResource(RMConnection *rmConnection, quint16 po
     register1Resource(rmConnection, NotZeroNumGen::getMsgNr(), QString("SAMPLE;S0;1;%2;%3;").arg(m_sDescription).arg(port));
 }
 
-void cSamplingInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void cSamplingInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/resources/samplinginterface.h
+++ b/zenux-service-common/lib/resources/samplinginterface.h
@@ -16,7 +16,7 @@ public:
     virtual void initSCPIConnection(QString leadingNodes) override;
     virtual void registerResource(RMConnection *rmConnection, quint16 port) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadSampleRate(const QString& scpi);
     QString scpiReadWritePLL(const QString& scpi);

--- a/zenux-service-common/lib/resources/scingroupresourceandinterface.cpp
+++ b/zenux-service-common/lib/resources/scingroupresourceandinterface.cpp
@@ -44,7 +44,7 @@ void ScInGroupResourceAndInterface::registerResource(RMConnection *rmConnection,
         register1Resource(rmConnection, NotZeroNumGen::getMsgNr(), QString("SCHEAD;%1;1;%2;%3;").arg(channel->getName(), channel->getDescription()).arg(port));
 }
 
-void ScInGroupResourceAndInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void ScInGroupResourceAndInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/resources/scingroupresourceandinterface.h
+++ b/zenux-service-common/lib/resources/scingroupresourceandinterface.h
@@ -18,7 +18,7 @@ public:
     void initSCPIConnection(QString leadingNodes) override;
     void registerResource(RMConnection *rmConnection, quint16 port) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadVersion(QString& sInput);
     QString m_ReadChannelCatalog(QString& sInput);

--- a/zenux-service-common/lib/scpi-interfaces/accumulatorinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/accumulatorinterface.cpp
@@ -30,7 +30,7 @@ void AccumulatorInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1SYSTEM:ACCUMULATOR").arg(leadingNodes),"SOC",SCPI::isQuery, m_scpiInterface, accumulatorCommands::cmdAccuStateOfCharge, &m_accuStateOfCharge);
 }
 
-void AccumulatorInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void AccumulatorInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/accumulatorinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/accumulatorinterface.h
@@ -17,7 +17,7 @@ public:
 signals:
     void sigAccumulatorStatusChange(uint8_t status);
 private:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     void getAccumulatorStatus();
     void getAccuStateOfCharge();
 

--- a/zenux-service-common/lib/scpi-interfaces/clamp.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/clamp.cpp
@@ -90,7 +90,7 @@ QString cClamp::getSerial()
     return m_sSerial;
 }
 
-void cClamp::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void cClamp::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode) {
     case cmdSerial:

--- a/zenux-service-common/lib/scpi-interfaces/clamp.h
+++ b/zenux-service-common/lib/scpi-interfaces/clamp.h
@@ -59,7 +59,7 @@ public:
     bool importClampAdjData();
 
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     bool importXMLDocument(QDomDocument* qdomdoc) override;
 
 private:

--- a/zenux-service-common/lib/scpi-interfaces/clampinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/clampinterface.cpp
@@ -116,7 +116,7 @@ void cClampInterface::actualizeClampStatus(quint16 devConnectedMask)
     }
 }
 
-void cClampInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void cClampInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode) {
     case ClampSystem::cmdClampChannelCat:

--- a/zenux-service-common/lib/scpi-interfaces/clampinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/clampinterface.h
@@ -38,7 +38,7 @@ public:
     QString importClampXmls(QString allXML, bool computeAndExport);
 
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 
 private:
     void generateAndNotifyClampChannelList();

--- a/zenux-service-common/lib/scpi-interfaces/commonscpimethods.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/commonscpimethods.cpp
@@ -6,9 +6,9 @@
 
 void CommonScpiMethods::sendProtoAnswer(QTcpSocket *telnetSocket,
                                         XiQNetWrapper *protobufWrapper,
-                                        cProtonetCommand *protoCmd)
+                                        ProtonetCommandPtr protoCmd)
 {
-    if(protoCmd->m_pPeer == 0) {
+    if(protoCmd->m_pPeer == nullptr) {
         // we worked on a command comming from scpi socket connection
         QString answer = protoCmd->m_sOutput+"\n";
         QByteArray ba = answer.toLatin1();
@@ -59,7 +59,6 @@ void CommonScpiMethods::sendProtoAnswer(QTcpSocket *telnetSocket,
             protoCmd->m_pPeer->writeRaw(block);
         }
     }
-    delete protoCmd;
 }
 
 QString CommonScpiMethods::handleScpiInterfaceRead(std::shared_ptr<cSCPI> scpiInterface,

--- a/zenux-service-common/lib/scpi-interfaces/commonscpimethods.h
+++ b/zenux-service-common/lib/scpi-interfaces/commonscpimethods.h
@@ -12,7 +12,7 @@ class CommonScpiMethods
 public:
     static void sendProtoAnswer(QTcpSocket* telnetSocket,
                                 XiQNetWrapper *protobufWrapper,
-                                cProtonetCommand* protoCmd);
+                                ProtonetCommandPtr protoCmd);
     static QString handleScpiInterfaceRead(std::shared_ptr<cSCPI> scpiInterface,
                                            const QString &scpiInput);
 };

--- a/zenux-service-common/lib/scpi-interfaces/finchannelinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/finchannelinterface.cpp
@@ -26,7 +26,7 @@ void FInChannelInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1%2").arg(leadingNodes, m_sName),"STATUS", SCPI::isQuery, m_scpiInterface, cmdStatus);
 }
 
-void FInChannelInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void FInChannelInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/finchannelinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/finchannelinterface.h
@@ -18,7 +18,7 @@ public:
     const QString& getDescription();
     bool isAvail();
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadAlias(const QString& scpi);
     QString scpiReadChannelStatus(const QString& scpi);

--- a/zenux-service-common/lib/scpi-interfaces/foutchannelinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/foutchannelinterface.cpp
@@ -46,7 +46,7 @@ void FOutChannelInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1%2").arg(leadingNodes, m_sName),"POWTYPE", SCPI::isQuery | SCPI::isCmdwP , m_scpiInterface, cmdPowtype, &notifierPowerType);
 }
 
-void FOutChannelInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void FOutChannelInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/foutchannelinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/foutchannelinterface.h
@@ -19,7 +19,7 @@ public:
     const QString& getDescription();
     bool isAvail();
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadAlias(const QString& scpi);
     QString scpiReadType(const QString& scpi);

--- a/zenux-service-common/lib/scpi-interfaces/hkinchannelinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/hkinchannelinterface.cpp
@@ -26,7 +26,7 @@ void HkInChannelInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1%2").arg(leadingNodes, m_sName),"STATUS", SCPI::isQuery, m_scpiInterface, cmdStatus);
 }
 
-void HkInChannelInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void HkInChannelInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/hkinchannelinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/hkinchannelinterface.h
@@ -18,7 +18,7 @@ public:
     QString& getDescription();
     bool isAvail();
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadAlias(const QString& scpi);
     QString scpiReadChannelStatus(const QString& scpi);

--- a/zenux-service-common/lib/scpi-interfaces/pcbserver.h
+++ b/zenux-service-common/lib/scpi-interfaces/pcbserver.h
@@ -29,14 +29,14 @@ signals:
     void notifierRegistred(NotificationString* notifier);
     void removeSubscribers(VeinTcp::TcpPeer* peer, const QByteArray &clientID);
 public slots:
-    void sendProtoAnswer(cProtonetCommand* protoCmd);
+    void sendProtoAnswer(ProtonetCommandPtr protoCmd);
 protected slots:
     virtual void onNotifySubscriber(ScpiNotificationSubscriber subscriber, QString newValue);
     virtual void onProtobufDisconnect(VeinTcp::TcpPeer *peer);
 protected:
     void connectProtoConnectionSignals();
     void initSCPIConnections();
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     void openTelnetScpi();
 
     SettingsContainerPtr m_settings;
@@ -55,8 +55,8 @@ private slots:
     void onTelnetDataReceived();
     void onTelnetDisconnect();
 private:
-    void registerNotifier(cProtonetCommand* protoCmd); // registeres 1 notifier per command
-    void unregisterNotifier(cProtonetCommand *protoCmd); // unregisters all notifiers
+    void registerNotifier(ProtonetCommandPtr protoCmd); // registeres 1 notifier per command
+    void unregisterNotifier(ProtonetCommandPtr protoCmd); // unregisters all notifiers
     void doUnregisterNotifier(VeinTcp::TcpPeer *peer, const QByteArray &clientID = QByteArray());
     void sendNotificationToClient(QString message, QByteArray clientID, VeinTcp::TcpPeer *netPeer);
     void executeCommandProto(VeinTcp::TcpPeer* peer, std::shared_ptr<google::protobuf::Message> cmd);

--- a/zenux-service-common/lib/scpi-interfaces/scinchannelinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/scinchannelinterface.cpp
@@ -26,7 +26,7 @@ void ScInChannelInterface::initSCPIConnection(QString leadingNodes)
     addDelegate(QString("%1%2").arg(leadingNodes, m_sName),"STATUS", SCPI::isQuery, m_scpiInterface, cmdStatus);
 }
 
-void ScInChannelInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void ScInChannelInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/scinchannelinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/scinchannelinterface.h
@@ -18,7 +18,7 @@ public:
     QString& getDescription();
     bool isAvail();
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString scpiReadAlias(const QString& scpi);
     QString scpiReadChannelStatus(const QString& scpi);

--- a/zenux-service-common/lib/scpi-interfaces/sensechannelcommon.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/sensechannelcommon.cpp
@@ -134,7 +134,7 @@ void SenseChannelCommon::setMMode(int mode)
     // but we can do this later
 }
 
-void SenseChannelCommon::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void SenseChannelCommon::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/sensechannelcommon.h
+++ b/zenux-service-common/lib/scpi-interfaces/sensechannelcommon.h
@@ -36,7 +36,7 @@ public:
     void setMMode(int mode);
 
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     virtual QString getAlias() = 0;
     virtual void setNotifierSenseChannelRange() = 0;
     virtual QString scpiReadWriteRange(QString& scpi) = 0;

--- a/zenux-service-common/lib/scpi-interfaces/senseinterfacecommon.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/senseinterfacecommon.cpp
@@ -446,7 +446,7 @@ QString SenseInterfaceCommon::exportXMLString(int indent)
     return justqdom.toString(indent);
 }
 
-void SenseInterfaceCommon::handleScpiReadWriteMMode(cProtonetCommand *protoCmd)
+void SenseInterfaceCommon::handleScpiReadWriteMMode(ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isQuery())
@@ -466,7 +466,7 @@ void SenseInterfaceCommon::handleScpiReadWriteMMode(cProtonetCommand *protoCmd)
         emit cmdExecutionDone(protoCmd);
 }
 
-void SenseInterfaceCommon::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void SenseInterfaceCommon::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/senseinterfacecommon.h
+++ b/zenux-service-common/lib/scpi-interfaces/senseinterfacecommon.h
@@ -85,7 +85,7 @@ protected:
     virtual bool isRangePartOfAdjXmlExport(SenseRangeCommon* range) = 0;
     bool importXMLDocument(QDomDocument* qdomdoc) override;
 
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 
     void setNotifierSenseMMode();
     void setNotifierSenseChannelCat();
@@ -99,7 +99,7 @@ protected:
     AdjDataPtr m_adjData;
 
 private:
-    void handleScpiReadWriteMMode(cProtonetCommand* protoCmd);
+    void handleScpiReadWriteMMode(ProtonetCommandPtr protoCmd);
     QString scpiReadVersion(const QString &scpi);
     QString scpiReadMModeCatalog(const QString& scpi);
     QString scpiReadSenseChannelCatalog(const QString& scpi);

--- a/zenux-service-common/lib/scpi-interfaces/senserangecommon.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/senserangecommon.cpp
@@ -112,7 +112,7 @@ void SenseRangeCommon::computeJustData()
     m_justdata->computeJustData();
 }
 
-void SenseRangeCommon::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void SenseRangeCommon::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     switch (cmdCode)
     {

--- a/zenux-service-common/lib/scpi-interfaces/senserangecommon.h
+++ b/zenux-service-common/lib/scpi-interfaces/senserangecommon.h
@@ -38,7 +38,7 @@ public:
 protected:
     bool m_bAvail; // range io avail or not
 private:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
     QString scpiRangeAlias(const QString& scpi) const;
     QString scpiRangeAvail(const QString& scpi) const;
     QString scpiRangeUpperRangeValue(const QString& scpi) const;

--- a/zenux-service-common/lib/scpi-interfaces/servicestatusinterface.cpp
+++ b/zenux-service-common/lib/scpi-interfaces/servicestatusinterface.cpp
@@ -33,7 +33,7 @@ void ServiceStatusInterface::initSCPIConnection(QString leadingNodes)
     connect(this, &ScpiConnection::removingSubscribers, this, &ServiceStatusInterface::onNotifierUnregistered);
 }
 
-void ServiceStatusInterface::executeProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void ServiceStatusInterface::executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     cSCPICommand cmd = protoCmd->m_sInput;
     if (cmd.isQuery()) {

--- a/zenux-service-common/lib/scpi-interfaces/servicestatusinterface.h
+++ b/zenux-service-common/lib/scpi-interfaces/servicestatusinterface.h
@@ -16,7 +16,7 @@ public:
                            AbstractFactoryI2cCtrlPtr ctrlFactory);
     virtual void initSCPIConnection(QString leadingNodes) override;
 protected:
-    void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) override;
+    void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) override;
 private:
     QString getControllerAvail();
     QString getAuthorizationStatus();

--- a/zenux-service-common/lib/scpi-protobuf/protonetcommand.cpp
+++ b/zenux-service-common/lib/scpi-protobuf/protonetcommand.cpp
@@ -1,8 +1,14 @@
 #include "protonetcommand.h"
 
-int cProtonetCommand::m_instanceCount = 0;
+int ProtonetCommand::m_instanceCount = 0;
 
-cProtonetCommand::cProtonetCommand(VeinTcp::TcpPeer *peer, bool hasClientId, bool withOutput, QByteArray clientid, quint32 messagenr, QString input, quint8 scpiType) :
+ProtonetCommand::ProtonetCommand(VeinTcp::TcpPeer *peer,
+                                 bool hasClientId,
+                                 bool withOutput,
+                                 const QByteArray &clientid,
+                                 quint32 messagenr,
+                                 const QString &input,
+                                 quint8 scpiType) :
     m_pPeer(peer),
     m_bhasClientId(hasClientId),
     m_bwithOutput(withOutput),
@@ -11,27 +17,28 @@ cProtonetCommand::cProtonetCommand(VeinTcp::TcpPeer *peer, bool hasClientId, boo
     m_sInput(input),
     m_nSCPIType(scpiType)
 {
+    qRegisterMetaType<ProtonetCommandPtr>();
     m_instanceCount++;
 }
 
-cProtonetCommand::cProtonetCommand(const cProtonetCommand *protoCmd) :
-    m_pPeer(protoCmd->m_pPeer),
-    m_bhasClientId(protoCmd->m_bhasClientId),
-    m_bwithOutput(protoCmd->m_bwithOutput),
-    m_clientId(protoCmd->m_clientId),
-    m_nmessageNr(protoCmd->m_nmessageNr),
-    m_sInput(protoCmd->m_sInput),
-    m_nSCPIType(protoCmd->m_nSCPIType)
+ProtonetCommand::ProtonetCommand(const ProtonetCommand &other) :
+    m_pPeer(other.m_pPeer),
+    m_bhasClientId(other.m_bhasClientId),
+    m_bwithOutput(other.m_bwithOutput),
+    m_clientId(other.m_clientId),
+    m_nmessageNr(other.m_nmessageNr),
+    m_sInput(other.m_sInput),
+    m_nSCPIType(other.m_nSCPIType)
 {
     m_instanceCount++;
 }
 
-cProtonetCommand::~cProtonetCommand()
+ProtonetCommand::~ProtonetCommand()
 {
     m_instanceCount--;
 }
 
-int cProtonetCommand::getInstanceCount()
+int ProtonetCommand::getInstanceCount()
 {
     return m_instanceCount;
 }

--- a/zenux-service-common/lib/scpi-protobuf/protonetcommand.h
+++ b/zenux-service-common/lib/scpi-protobuf/protonetcommand.h
@@ -4,19 +4,20 @@
 #include <vtcp_peer.h>
 #include <QByteArray>
 #include <QString>
+#include <memory>
 
-class cProtonetCommand
+class ProtonetCommand
 {
 public:
-    cProtonetCommand(VeinTcp::TcpPeer* peer,
-                     bool hasClientId,
-                     bool withOutput,
-                     QByteArray clientid,
-                     quint32 messagenr,
-                     QString input,
-                     quint8 scpiType = 0);
-    cProtonetCommand(const cProtonetCommand* protoCmd);
-    virtual ~cProtonetCommand();
+    ProtonetCommand(VeinTcp::TcpPeer* peer,
+                    bool hasClientId,
+                    bool withOutput,
+                    const QByteArray &clientid,
+                    quint32 messagenr,
+                    const QString &input,
+                    quint8 scpiType = 0);
+    ProtonetCommand(const ProtonetCommand& other);
+    virtual ~ProtonetCommand();
     static int getInstanceCount();
 
     VeinTcp::TcpPeer* m_pPeer;
@@ -30,5 +31,8 @@ public:
 private:
     static int m_instanceCount;
 };
+
+typedef std::shared_ptr<ProtonetCommand> ProtonetCommandPtr;
+Q_DECLARE_METATYPE(ProtonetCommandPtr)
 
 #endif // PROTONETCOMMAND_H

--- a/zenux-service-common/lib/scpi-protobuf/scpiconnection.cpp
+++ b/zenux-service-common/lib/scpi-protobuf/scpiconnection.cpp
@@ -37,7 +37,7 @@ void ScpiConnection::addDelegate(QString cmdParent, QString cmd, quint8 type, st
     connect(delegate, &cSCPIDelegate::sigNotifySubcriber, this, &ScpiConnection::sigNotifySubcriber);
 }
 
-void ScpiConnection::onExecuteProtoScpi(int cmdCode, cProtonetCommand *protoCmd)
+void ScpiConnection::onExecuteProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd)
 {
     executeProtoScpi(cmdCode, protoCmd);
 }

--- a/zenux-service-common/lib/scpi-protobuf/scpiconnection.h
+++ b/zenux-service-common/lib/scpi-protobuf/scpiconnection.h
@@ -16,21 +16,21 @@ public:
     virtual void initSCPIConnection(QString leadingNodes) = 0;
 signals:
     void valNotifier(NotificationValue* notifier);
-    void cmdExecutionDone(cProtonetCommand* protoCmd);
+    void cmdExecutionDone(ProtonetCommandPtr protoCmd);
     void sigNotifySubcriber(ScpiNotificationSubscriber subscriber, QString newValue);
     void removingSubscribers(VeinTcp::TcpPeer* peer, const QByteArray &clientID);
 public slots:
     virtual void onNotifierRegistered(NotificationString* notifier);
     void onRemoveSubscribers(VeinTcp::TcpPeer *peer, const QByteArray &clientID);
 protected:
-    virtual void executeProtoScpi(int cmdCode, cProtonetCommand* protoCmd) = 0;
+    virtual void executeProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd) = 0;
     void removeSCPIConnections();
     void ensureTrailingColonOnNonEmptyParentNodes(QString &leadingNodes);
     void addDelegate(QString cmdParent, QString cmd, quint8 type, std::shared_ptr<cSCPI> scpiInterface, quint16 cmdCode, NotificationString *notificationString = nullptr);
     std::shared_ptr<cSCPI> m_scpiInterface;
     QList<cSCPIDelegate*> m_DelegateList;
 private slots:
-    void onExecuteProtoScpi(int cmdCode, cProtonetCommand* protoCmd);
+    void onExecuteProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd);
 };
 
 #endif // SCPICONNECTION_H

--- a/zenux-service-common/lib/scpi-protobuf/scpidelegate.cpp
+++ b/zenux-service-common/lib/scpi-protobuf/scpidelegate.cpp
@@ -16,7 +16,7 @@ cSCPIDelegate::cSCPIDelegate(QString cmdParent,
         connect(m_notificationString, &NotificationString::valueChanged, this, &cSCPIDelegate::notifyAllSubscribers);
 }
 
-bool cSCPIDelegate::executeSCPI(cProtonetCommand *protoCmd)
+bool cSCPIDelegate::executeSCPI(ProtonetCommandPtr protoCmd)
 {
     emit sigExecuteProtoScpi(m_nCmdCode, protoCmd);
     return true;

--- a/zenux-service-common/lib/scpi-protobuf/scpidelegate.h
+++ b/zenux-service-common/lib/scpi-protobuf/scpidelegate.h
@@ -19,14 +19,14 @@ public:
                   quint16 cmdCode,
                   NotificationString *notificationString = nullptr);
     virtual bool executeSCPI(const QString&, QString&) override { return false; }
-    virtual bool executeSCPI(cProtonetCommand* protoCmd);
+    virtual bool executeSCPI(ProtonetCommandPtr protoCmd);
     QString getCommand();
     NotificationString *getNotificationString();
     ScpiNotificationSubscriberHandler &getScpiNotificationSubscriberHandler();
 public slots:
     void notifyAllSubscribers(QString newValue);
 signals:
-    void sigExecuteProtoScpi(int cmdCode, cProtonetCommand* protoCmd);
+    void sigExecuteProtoScpi(int cmdCode, ProtonetCommandPtr protoCmd);
     void sigNotifySubcriber(ScpiNotificationSubscriber subscriber, QString newValue);
 private:
     quint16 m_nCmdCode;

--- a/zenux-service-common/testlib/testpcbservernotifications.cpp
+++ b/zenux-service-common/testlib/testpcbservernotifications.cpp
@@ -27,7 +27,7 @@ void TestPcbServerNotifications::initTestSCPIConnections()
 void TestPcbServerNotifications::registerNotifier(QString inputCmd, int notifierId)
 {
     QString scpiAuthorizationQuery = QString("%1 %2;%3;").arg("SERVER:REGISTER").arg(inputCmd).arg(notifierId);
-    cProtonetCommand* protoCmd = new cProtonetCommand(nullptr, false, false, QByteArray(), 0, scpiAuthorizationQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, false, QByteArray(), 0, scpiAuthorizationQuery);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(m_scpiInterface->getSCPIObject("SERVER:REGISTER"));
     scpiDelegate->executeSCPI(protoCmd);
 }
@@ -35,7 +35,7 @@ void TestPcbServerNotifications::registerNotifier(QString inputCmd, int notifier
 void TestPcbServerNotifications::unregisterNotifier()
 {
     QString scpiAuthorizationQuery = QString("%1 %2;").arg("SERVER:UNREGISTER").arg("");
-    cProtonetCommand* protoCmd = new cProtonetCommand(nullptr, false, false, QByteArray(), 0, scpiAuthorizationQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, false, QByteArray(), 0, scpiAuthorizationQuery);
     cSCPIObject* scpiObject = m_scpiInterface->getSCPIObject("SERVER:UNREGISTER");
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
     scpiDelegate->executeSCPI(protoCmd);

--- a/zenux-service-common/tests/test_accumulatorinterface.cpp
+++ b/zenux-service-common/tests/test_accumulatorinterface.cpp
@@ -51,10 +51,10 @@ void test_accumulatorinterface::findObjects()
 void test_accumulatorinterface::readAccuStatus()
 {
     TimeMachineForTest::getInstance()->processTimers(1500);
-    std::unique_ptr<cProtonetCommand> protoCmd = std::make_unique<cProtonetCommand>(nullptr, false, false, QByteArray(), 0, systemAccumulatorStatus);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, false, QByteArray(), 0, systemAccumulatorStatus);
     cSCPIObject* scpiObject = m_scpiInterface->getSCPIObject(systemAccumulatorStatus);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
-    scpiDelegate->executeSCPI(protoCmd.get());
+    scpiDelegate->executeSCPI(protoCmd);
     if(m_accuSettings->isAvailable())
         QCOMPARE(protoCmd->m_sOutput, "0");
     else
@@ -64,10 +64,10 @@ void test_accumulatorinterface::readAccuStatus()
 void test_accumulatorinterface::readAccuStateOfCharge()
 {
     TimeMachineForTest::getInstance()->processTimers(1500);
-    std::unique_ptr<cProtonetCommand> protoCmd = std::make_unique<cProtonetCommand>(nullptr, false, false, QByteArray(), 0, systemAccumulatorSoc);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, false, QByteArray(), 0, systemAccumulatorSoc);
     cSCPIObject* scpiObject = m_scpiInterface->getSCPIObject(systemAccumulatorSoc);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
-    scpiDelegate->executeSCPI(protoCmd.get());
+    scpiDelegate->executeSCPI(protoCmd);
     if(m_accuSettings->isAvailable())
         QCOMPARE(protoCmd->m_sOutput, "37");
     else

--- a/zenux-service-common/tests/test_authorizationnotifier.cpp
+++ b/zenux-service-common/tests/test_authorizationnotifier.cpp
@@ -55,7 +55,7 @@ void test_authorizationnotifier::cleanup()
 
 QString test_authorizationnotifier::getAuthoStatus()
 {
-    cProtonetCommand* protoCmd = new cProtonetCommand(0, false, false, QByteArray(), 0, statusAuthorizationCommand);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, false, QByteArray(), 0, statusAuthorizationCommand);
 
     cSCPIObject* scpiObject = m_pcbServerTest->getSCPIInterface()->getSCPIObject(statusAuthorizationCommand);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);
@@ -83,7 +83,7 @@ void test_authorizationnotifier::getInitialAuthoStatus()
 void test_authorizationnotifier::getNotiferId()
 {
     QString scpiAuthorizationQuery = QString("%1 %2;%3;").arg(registerNotifierCommand).arg(statusAuthorizationCommand).arg(NOTIFICATION_ID);
-    cProtonetCommand* protoCmd = new cProtonetCommand(nullptr, false, false, QByteArray(), 0, scpiAuthorizationQuery);
+    ProtonetCommandPtr protoCmd = std::make_shared<ProtonetCommand>(nullptr, false, false, QByteArray(), 0, scpiAuthorizationQuery);
 
     cSCPIObject* scpiObject = m_pcbServerTest->getSCPIInterface()->getSCPIObject(registerNotifierCommand);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObject);

--- a/zenux-service-common/tests/test_justdata.cpp
+++ b/zenux-service-common/tests/test_justdata.cpp
@@ -33,14 +33,14 @@ void test_justdata::nodeSetAndRead()
     QString scpiStringWrite = "sens:m0:8V:corr:offset:node:0 0.1;0.02;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
 
     QString scpiStringRead = "sens:m0:8V:corr:offset:node:0?";
     cSCPIObject* scpiObjectRead = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectRead != nullptr);
-    cProtonetCommand* protoCmdRead = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringRead);
+    ProtonetCommandPtr protoCmdRead = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringRead);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectRead);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdRead));
     QCOMPARE((protoCmdRead->m_sOutput), "0.1000;0.0200;");
@@ -51,14 +51,14 @@ void test_justdata::coeffSetAndRead()
     QString scpiStringWrite = "sens:m0:8V:corr:offset:coef:0 0.1234569;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
 
     QString scpiStringRead = "sens:m0:8V:corr:offset:coef:0?";
     cSCPIObject* scpiObjectRead = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectRead != nullptr);
-    cProtonetCommand* protoCmdRead = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringRead);
+    ProtonetCommandPtr protoCmdRead = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringRead);
     scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectRead);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdRead));
     QCOMPARE((protoCmdRead->m_sOutput), "0.123457"); // no fixed digits (arg() defaults to 6 digit + rounding??)
@@ -72,7 +72,7 @@ void test_justdata::nodeSetReject()
     QString scpiStringWrite = "sens:m1:8V:corr:offset:node:0 0.1;0.02;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
     QCOMPARE((protoCmdWrite->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::erraut]);
@@ -86,7 +86,7 @@ void test_justdata::coeffSetReject()
     QString scpiStringWrite = "sens:m1:8V:corr:offset:coef:0 0.1;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
     QCOMPARE((protoCmdWrite->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::erraut]);
@@ -100,7 +100,7 @@ void test_justdata::nodeSetFail()
     QString scpiStringWrite = "sens:m1:8V:corr:offset:node:0 0.1;0.02;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
     QCOMPARE((protoCmdWrite->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::errexec]);
@@ -114,7 +114,7 @@ void test_justdata::coeffSetFail()
     QString scpiStringWrite = "sens:m1:8V:corr:offset:coef:0 0.1;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
     QCOMPARE((protoCmdWrite->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::errexec]);
@@ -125,7 +125,7 @@ void test_justdata::nodeSetOneCrap()
     QString scpiStringWrite = "sens:m0:8V:corr:offset:node:0 0.01;bar;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
     QCOMPARE((protoCmdWrite->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::errval]);
@@ -136,7 +136,7 @@ void test_justdata::nodeSettwoCrap()
     QString scpiStringWrite = "sens:m0:8V:corr:offset:node:0 foo;0.01;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand* protoCmdWrite = new cProtonetCommand(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr protoCmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
     QVERIFY(scpiDelegate->executeSCPI(protoCmdWrite));
     QCOMPARE((protoCmdWrite->m_sOutput), ZSCPI::scpiAnswer[ZSCPI::errval]);
@@ -147,8 +147,8 @@ void test_justdata::coefSetCrap()
     QString scpiStringWrite = "sens:m0:8V:corr:offset:coef:0 foo;";
     cSCPIObject* scpiObjectWrite = m_scpiInterface->getSCPIObject(scpiStringWrite);
     QVERIFY(scpiObjectWrite != nullptr);
-    cProtonetCommand cmdWrite(0, false, true, QByteArray(), 0, scpiStringWrite);
+    ProtonetCommandPtr cmdWrite = std::make_shared<ProtonetCommand>(nullptr, false, true, QByteArray(), 0, scpiStringWrite);
     cSCPIDelegate* scpiDelegate = static_cast<cSCPIDelegate*>(scpiObjectWrite);
-    QVERIFY(scpiDelegate->executeSCPI(&cmdWrite));
-    QCOMPARE(cmdWrite.m_sOutput, ZSCPI::scpiAnswer[ZSCPI::errval]);
+    QVERIFY(scpiDelegate->executeSCPI(cmdWrite));
+    QCOMPARE(cmdWrite->m_sOutput, ZSCPI::scpiAnswer[ZSCPI::errval]);
 }


### PR DESCRIPTION
…> ProtonetCommand